### PR TITLE
[codex] Codex rule import 본문 인라인 처리

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: sigstore/cosign-installer@v3
+
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex Rule Import Materialization**: Codex 하네스가 `@import content/rules/...` 포인터를 그대로 남기지 않고 실제 규칙 본문을 인라인하도록 수정
+  - `pkg/adapter/codex/codex_rules.go` — Codex 규칙 생성 시 embedded `content/rules/*.md`를 로드하여 import 해석
+  - `pkg/adapter/codex/codex_rules.go` — frontmatter와 중복 H1 제목 제거로 Codex 규칙 파일 형식 정규화
+  - `pkg/adapter/codex/codex_rules_test.go` — unresolved import와 duplicate heading 회귀 테스트 추가
+
 ### Added
 
 - **Init Platform Auto-Detection**: `auto init` without `--platforms` now scans PATH for supported installed coding CLIs and installs all detected supported platforms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
   - `pkg/adapter/codex/codex_rules.go` — frontmatter와 중복 H1 제목 제거로 Codex 규칙 파일 형식 정규화
   - `pkg/adapter/codex/codex_rules_test.go` — unresolved import와 duplicate heading 회귀 테스트 추가
 
+- **Release Workflow Cosign Bootstrap**: GitHub Release 워크플로우가 `cosign` 부재로 실패하던 문제 수정
+  - `.github/workflows/release.yaml` — `sigstore/cosign-installer@v3` 추가로 checksum 서명 단계 선행 설치
+
 ### Added
 
 - **Init Platform Auto-Detection**: `auto init` without `--platforms` now scans PATH for supported installed coding CLIs and installs all detected supported platforms

--- a/pkg/adapter/codex/codex_rules.go
+++ b/pkg/adapter/codex/codex_rules.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	builtincontent "github.com/insajin/autopus-adk/content"
 	"github.com/insajin/autopus-adk/pkg/adapter"
 	"github.com/insajin/autopus-adk/pkg/config"
-	"github.com/insajin/autopus-adk/pkg/content"
+	contentutil "github.com/insajin/autopus-adk/pkg/content"
 	"github.com/insajin/autopus-adk/templates"
 )
 
@@ -16,7 +17,7 @@ const codexRulesTemplateDir = "codex/rules/autopus"
 
 // fileSizeLimitData is the template data for the file-size-limit rule.
 type fileSizeLimitData struct {
-	Exclusions []content.FileSizeExclusion
+	Exclusions []contentutil.FileSizeExclusion
 }
 
 // generateRuleFiles reads Codex rule templates from embedded FS,
@@ -66,7 +67,7 @@ func (a *Adapter) prepareRuleMappings(cfg *config.HarnessConfig) ([]adapter.File
 		// file-size-limit uses a special data struct with exclusions.
 		var rendered string
 		if outFile == "file-size-limit.md" {
-			exclusions := content.FileSizeExclusions(cfg.Stack, cfg.Framework)
+			exclusions := contentutil.FileSizeExclusions(cfg.Stack, cfg.Framework)
 			data := fileSizeLimitData{Exclusions: exclusions}
 			rendered, err = a.engine.RenderString(string(tmplContent), data)
 		} else {
@@ -74,6 +75,10 @@ func (a *Adapter) prepareRuleMappings(cfg *config.HarnessConfig) ([]adapter.File
 		}
 		if err != nil {
 			return nil, fmt.Errorf("codex rule 템플릿 렌더링 실패 %s: %w", name, err)
+		}
+		rendered, err = resolveCodexRuleImports(rendered)
+		if err != nil {
+			return nil, fmt.Errorf("codex rule import 해석 실패 %s: %w", name, err)
 		}
 
 		relPath := ruleFilePath(outFile)
@@ -86,6 +91,34 @@ func (a *Adapter) prepareRuleMappings(cfg *config.HarnessConfig) ([]adapter.File
 	}
 
 	return files, nil
+}
+
+// resolveCodexRuleImports materializes content/rules imports because Codex
+// rule files are consumed as plain markdown files rather than through an
+// import-aware rule loader.
+func resolveCodexRuleImports(rendered string) (string, error) {
+	const importPrefix = "@import content/rules/"
+
+	lines := strings.Split(rendered, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, importPrefix) {
+			continue
+		}
+
+		contentPath := strings.TrimPrefix(trimmed, "@import ")
+		embeddedPath := strings.TrimPrefix(contentPath, "content/")
+
+		imported, err := builtincontent.FS.ReadFile(embeddedPath)
+		if err != nil {
+			return "", fmt.Errorf("embedded rule 읽기 실패 %s: %w", embeddedPath, err)
+		}
+
+		body := stripFrontmatter(string(imported))
+		lines[i] = strings.TrimSpace(stripLeadingHeading(body))
+	}
+
+	return strings.Join(lines, "\n"), nil
 }
 
 // ruleFilePath returns the target path for a rule file.
@@ -126,4 +159,24 @@ func stripFrontmatter(content string) string {
 		body = body[1:]
 	}
 	return body
+}
+
+// stripLeadingHeading removes the first markdown H1 because the codex rule
+// wrapper template already defines the rule title.
+func stripLeadingHeading(content string) string {
+	lines := strings.Split(content, "\n")
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+
+	if len(lines) == 0 || !strings.HasPrefix(strings.TrimSpace(lines[0]), "# ") {
+		return content
+	}
+
+	lines = lines[1:]
+	for len(lines) > 0 && strings.TrimSpace(lines[0]) == "" {
+		lines = lines[1:]
+	}
+
+	return strings.Join(lines, "\n")
 }

--- a/pkg/adapter/codex/codex_rules_test.go
+++ b/pkg/adapter/codex/codex_rules_test.go
@@ -70,6 +70,18 @@ func TestGenerateRuleFiles_Content(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(loreData), "Lore Commit",
 		"should contain rule title")
+	assert.NotContains(t, string(loreData), "@import content/rules/",
+		"codex rules should inline imported rule bodies")
+	assert.NotContains(t, string(loreData), "# Lore Commit\n\n# Lore Commit",
+		"codex rules should not duplicate the title after inlining")
+
+	contextPath := filepath.Join(dir, ".codex", "rules", "autopus", "context7-docs.md")
+	contextData, err := os.ReadFile(contextPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(contextData), "Before any technology/library/framework-related work",
+		"context7-docs should include imported rule content")
+	assert.NotContains(t, string(contextData), "@import content/rules/",
+		"context7-docs should not leave unresolved imports")
 }
 
 func TestAgentsMD_NoInlineRules(t *testing.T) {


### PR DESCRIPTION
## What changed
- materialize `@import content/rules/...` references when generating Codex rule files
- strip frontmatter and duplicated H1 headings from imported rule bodies
- add regression coverage for unresolved imports and duplicate headings

## Why
Codex consumes generated rule files as plain markdown, so unresolved `@import` lines left key harness rules effectively unapplied.

## Validation
- `go test ./pkg/adapter/codex/...`
- `go test ./...` (fails in unrelated existing tests: `pkg/pipeline`, `pkg/worker/adapter`)
