### PR TITLE
[codex] 워커 런타임 운영 이슈 수정

### DIFF
--- a/pkg/worker/a2a/coverage_gap_test.go
+++ b/pkg/worker/a2a/coverage_gap_test.go
@@ -50,6 +50,33 @@ func TestServer_SetAuthToken(t *testing.T) {
 	assert.Equal(t, "new-secret-token", got)
 }
 
+func TestServer_SetAuthToken_PropagatesToDependencies(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(ServerConfig{
+		BackendURL: "ws://localhost:9999",
+		WorkerName: "w1",
+		Handler:    func(_ context.Context, _ string, _ json.RawMessage) (*TaskResult, error) { return nil, nil },
+	})
+	srv.transport = NewTransport(TransportConfig{URL: "wss://example.com/ws", AuthToken: "old"})
+	poller := NewRESTPoller(RESTPollerConfig{
+		BackendURL:  "http://localhost:9999",
+		AuthToken:   "old",
+		WorkerID:    "w1",
+		TaskHandler: func(_ PollResult) error { return nil },
+	})
+	srv.SetRESTPoller(poller)
+
+	srv.SetAuthToken("new-secret-token")
+
+	srv.mu.Lock()
+	gotPoller := srv.restPoller
+	srv.mu.Unlock()
+	require.NotNil(t, gotPoller)
+	assert.Equal(t, "new-secret-token", srv.transport.config.AuthToken)
+	assert.Equal(t, "new-secret-token", gotPoller.config.AuthToken)
+}
+
 func TestServer_SetRESTPoller(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/worker/a2a/rest_poller.go
+++ b/pkg/worker/a2a/rest_poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -102,6 +103,13 @@ func (p *RESTPoller) Stop() {
 	p.active = false
 }
 
+// SetAuthToken updates the bearer token used by the poller.
+func (p *RESTPoller) SetAuthToken(token string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config.AuthToken = token
+}
+
 func (p *RESTPoller) loop(ctx context.Context) {
 	ticker := time.NewTicker(p.config.PollInterval)
 	defer ticker.Stop()
@@ -119,12 +127,16 @@ func (p *RESTPoller) loop(ctx context.Context) {
 }
 
 func (p *RESTPoller) poll(ctx context.Context) error {
-	pollURL := fmt.Sprintf("%s/api/a2a/poll?worker_id=%s", p.config.BackendURL, url.QueryEscape(p.config.WorkerID))
+	p.mu.Lock()
+	authToken := p.config.AuthToken
+	p.mu.Unlock()
+
+	pollURL := fmt.Sprintf("%s/api/worker/tasks/pending?worker_id=%s", p.config.BackendURL, url.QueryEscape(p.config.WorkerID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pollURL, nil)
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+p.config.AuthToken)
+	req.Header.Set("Authorization", "Bearer "+authToken)
 
 	resp, err := p.client.Do(req)
 	if err != nil {
@@ -142,12 +154,12 @@ func (p *RESTPoller) poll(ctx context.Context) error {
 		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
 	}
 
-	var result pollResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return fmt.Errorf("decode response: %w", err)
+	tasks, err := decodePollTasks(resp.Body)
+	if err != nil {
+		return err
 	}
 
-	for _, task := range result.Tasks {
+	for _, task := range tasks {
 		if p.config.TaskHandler != nil {
 			if err := p.config.TaskHandler(task); err != nil {
 				log.Printf("[rest-poller] task handler error for %s: %v", task.ID, err)
@@ -155,4 +167,23 @@ func (p *RESTPoller) poll(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func decodePollTasks(body io.Reader) ([]PollResult, error) {
+	payload, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var wrapped pollResponse
+	if err := json.Unmarshal(payload, &wrapped); err == nil && wrapped.Tasks != nil {
+		return wrapped.Tasks, nil
+	}
+
+	var direct []PollResult
+	if err := json.Unmarshal(payload, &direct); err == nil {
+		return direct, nil
+	}
+
+	return nil, fmt.Errorf("decode response: unsupported poll response shape")
 }

--- a/pkg/worker/a2a/rest_poller_test.go
+++ b/pkg/worker/a2a/rest_poller_test.go
@@ -29,23 +29,23 @@ func TestRESTPoller_ActivatesWhenWebSocketExhausted(t *testing.T) {
 
 	// Given a mock backend poll endpoint
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/a2a/poll" {
+		if r.URL.Path != "/api/worker/tasks/pending" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		pollCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"tasks": []interface{}{}})
+		_ = json.NewEncoder(w).Encode([]interface{}{})
 	}))
 	defer srv.Close()
 
 	// When NewRESTPoller is created and started (type does not exist yet — compile error)
 	poller := NewRESTPoller(RESTPollerConfig{ // NewRESTPoller and RESTPollerConfig do not exist yet
-		BackendURL:    srv.URL,
-		AuthToken:     "valid-token",
-		WorkerID:      "w1",
-		PollInterval:  20 * time.Millisecond, // short for test; real is 10s
-		TaskHandler:   func(task PollResult) error { return nil }, // PollResult does not exist yet
+		BackendURL:   srv.URL,
+		AuthToken:    "valid-token",
+		WorkerID:     "w1",
+		PollInterval: 20 * time.Millisecond,                      // short for test; real is 10s
+		TaskHandler:  func(task PollResult) error { return nil }, // PollResult does not exist yet
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -72,19 +72,17 @@ func TestRESTPoller_ProcessesQueuedTasks(t *testing.T) {
 
 	// Given a backend that returns one task
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/a2a/poll" {
+		if r.URL.Path != "/api/worker/tasks/pending" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"tasks": []interface{}{
-				map[string]interface{}{
-					"id":   "poll-task-001",
-					"type": "symphony_run",
-					"payload": map[string]interface{}{
-						"step": "test",
-					},
+		_ = json.NewEncoder(w).Encode([]interface{}{
+			map[string]interface{}{
+				"id":   "poll-task-001",
+				"type": "symphony_run",
+				"payload": map[string]interface{}{
+					"step": "test",
 				},
 			},
 		})
@@ -135,7 +133,7 @@ func TestRESTPoller_StopsWhenWebSocketRecovers(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pollCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"tasks": []interface{}{}})
+		_ = json.NewEncoder(w).Encode([]interface{}{})
 	}))
 	defer srv.Close()
 
@@ -199,4 +197,44 @@ func TestRESTPoller_AuthFailure_SurfacesError(t *testing.T) {
 
 	// Then auth error is surfaced
 	assert.Greater(t, authErrors.Load(), int32(0), "401 from poll endpoint must surface auth error (S11)")
+}
+
+func TestRESTPoller_SetAuthToken(t *testing.T) {
+	t.Parallel()
+
+	poller := NewRESTPoller(RESTPollerConfig{
+		BackendURL:  "http://localhost:9999",
+		AuthToken:   "old-token",
+		WorkerID:    "w1",
+		TaskHandler: func(_ PollResult) error { return nil },
+	})
+
+	poller.SetAuthToken("new-token")
+
+	assert.Equal(t, "new-token", poller.config.AuthToken)
+}
+
+func TestRESTPoller_DecodeWrappedResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"tasks": []interface{}{
+				map[string]interface{}{"id": "wrapped-1", "type": "symphony_run"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	var got string
+	poller := NewRESTPoller(RESTPollerConfig{
+		BackendURL:  srv.URL,
+		AuthToken:   "valid-token",
+		WorkerID:    "w1",
+		TaskHandler: func(task PollResult) error { got = task.ID; return nil },
+	})
+
+	require.NoError(t, poller.poll(context.Background()))
+	assert.Equal(t, "wrapped-1", got)
 }

--- a/pkg/worker/a2a/server.go
+++ b/pkg/worker/a2a/server.go
@@ -144,7 +144,16 @@ func (s *Server) UpdateTaskStatus(taskID string, status TaskStatus, result *Task
 func (s *Server) SetAuthToken(token string) {
 	s.mu.Lock()
 	s.config.AuthToken = token
+	transport := s.transport
+	restPoller := s.restPoller
 	s.mu.Unlock()
+
+	if transport != nil {
+		transport.SetAuthToken(token)
+	}
+	if restPoller != nil {
+		restPoller.SetAuthToken(token)
+	}
 }
 
 // SetRESTPoller attaches a REST poller that activates when WebSocket connection is exhausted.

--- a/pkg/worker/a2a/ws_transport.go
+++ b/pkg/worker/a2a/ws_transport.go
@@ -155,6 +155,13 @@ func (t *Transport) Close() error {
 	return t.conn.Close()
 }
 
+// SetAuthToken updates the bearer token used for future connects/reconnects.
+func (t *Transport) SetAuthToken(token string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.config.AuthToken = token
+}
+
 // startHeartbeat sends ping frames at the configured interval.
 func (t *Transport) startHeartbeat(ctx context.Context) {
 	ticker := time.NewTicker(time.Duration(t.config.HeartbeatSec) * time.Second)

--- a/pkg/worker/adapter/codex.go
+++ b/pkg/worker/adapter/codex.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strings"
 )
 
 // CodexAdapter implements ProviderAdapter for OpenAI Codex CLI.
@@ -21,21 +22,20 @@ func (a *CodexAdapter) Name() string { return "codex" }
 
 // BuildCommand constructs the exec.Cmd for Codex CLI.
 func (a *CodexAdapter) BuildCommand(ctx context.Context, task TaskConfig) *exec.Cmd {
-	sessionID := task.SessionID
-	if sessionID == "" {
-		sessionID = fmt.Sprintf("worker-sess-%s", task.TaskID)
-	}
-
 	args := []string{"exec"}
 	if task.Prompt != "" {
 		// Read the sensitive task prompt from stdin instead of exposing it
 		// in the process argv where other local processes can inspect it.
 		args = append(args, "-")
 	}
-	args = append(args, "--json", "resume", sessionID)
+	args = append(args, "--json")
 
-	if task.Model != "" {
+	if task.Model != "" && !strings.HasPrefix(task.Model, "openai/") {
 		args = append(args, "-m", task.Model)
+	} else if strings.HasPrefix(task.Model, "openai/") {
+		slog.Warn("openai/* model not supported by codex CLI account, omitting explicit model override",
+			"task_id", task.TaskID,
+			"model", task.Model)
 	}
 
 	if task.ComputerUse {

--- a/pkg/worker/adapter/codex_test.go
+++ b/pkg/worker/adapter/codex_test.go
@@ -28,8 +28,7 @@ func TestCodexAdapterBuildCommand(t *testing.T) {
 	assert.Contains(t, cmd.Args, "-")
 	assert.NotContains(t, cmd.Args, "fix the bug")
 	assert.Contains(t, cmd.Args, "--json")
-	assert.Contains(t, cmd.Args, "resume")
-	assert.Contains(t, cmd.Args, "worker-sess-task-c1")
+	assert.NotContains(t, cmd.Args, "resume")
 	assert.Equal(t, "/tmp/codex-work", cmd.Dir)
 
 	envContains(t, cmd.Env, "AUTOPUS_TASK_ID=task-c1")
@@ -44,7 +43,8 @@ func TestCodexAdapterBuildCommandWithSession(t *testing.T) {
 	}
 
 	cmd := a.BuildCommand(context.Background(), task)
-	assert.Contains(t, cmd.Args, "my-session")
+	assert.NotContains(t, cmd.Args, "resume")
+	assert.NotContains(t, cmd.Args, "my-session")
 }
 
 func TestCodexAdapterBuildCommandWithModel(t *testing.T) {
@@ -57,6 +57,18 @@ func TestCodexAdapterBuildCommandWithModel(t *testing.T) {
 	cmd := a.BuildCommand(context.Background(), task)
 	assert.Contains(t, cmd.Args, "-m")
 	assert.Contains(t, cmd.Args, "o3")
+}
+
+func TestCodexAdapterBuildCommand_OmitsOpenAIModelOverride(t *testing.T) {
+	a := NewCodexAdapter()
+	task := TaskConfig{
+		TaskID: "task-cm2",
+		Model:  "openai/gpt-5.4",
+	}
+
+	cmd := a.BuildCommand(context.Background(), task)
+	assert.NotContains(t, cmd.Args, "-m")
+	assert.NotContains(t, cmd.Args, "openai/gpt-5.4")
 }
 
 func TestCodexAdapterParseEvent(t *testing.T) {

--- a/pkg/worker/knowledge/memory.go
+++ b/pkg/worker/knowledge/memory.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,6 +17,7 @@ type MemorySearcher struct {
 	authToken   string
 	workspaceID string
 	client      *http.Client
+	mu          sync.RWMutex
 }
 
 // MemoryEntry represents a single memory entry from the Platform.
@@ -92,7 +94,7 @@ func (ms *MemorySearcher) GetContext(ctx context.Context, agentID, description s
 	}
 	req.URL.RawQuery = q.Encode()
 
-	req.Header.Set("Authorization", "Bearer "+ms.authToken)
+	req.Header.Set("Authorization", "Bearer "+ms.getAuthToken())
 
 	resp, err := ms.client.Do(req)
 	if err != nil {
@@ -137,7 +139,7 @@ func (ms *MemorySearcher) CreateMemory(ctx context.Context, req CreateMemoryRequ
 	if err != nil {
 		return fmt.Errorf("memory write-back: create request: %w", err)
 	}
-	httpReq.Header.Set("Authorization", "Bearer "+ms.authToken)
+	httpReq.Header.Set("Authorization", "Bearer "+ms.getAuthToken())
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := ms.client.Do(httpReq)
@@ -150,4 +152,17 @@ func (ms *MemorySearcher) CreateMemory(ctx context.Context, req CreateMemoryRequ
 		return fmt.Errorf("memory write-back: unexpected status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// SetAuthToken updates the bearer token used for memory API requests.
+func (ms *MemorySearcher) SetAuthToken(token string) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	ms.authToken = token
+}
+
+func (ms *MemorySearcher) getAuthToken() string {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.authToken
 }

--- a/pkg/worker/knowledge/memory_test.go
+++ b/pkg/worker/knowledge/memory_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestMemorySearcher_GetContext(t *testing.T) {
 	t.Parallel()
 
@@ -183,4 +182,23 @@ func TestExtractKeywords(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMemorySearcher_SetAuthToken(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(MemoryContextResponse{})
+	}))
+	defer srv.Close()
+
+	ms := NewMemorySearcher(srv.URL, "old-token", "ws-1")
+	ms.SetAuthToken("new-token")
+
+	_, err := ms.GetContext(context.Background(), "agent-1", "test")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer new-token", gotAuth)
 }

--- a/pkg/worker/knowledge/search.go
+++ b/pkg/worker/knowledge/search.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -16,6 +17,7 @@ type KnowledgeSearcher struct {
 	authToken   string
 	workspaceID string
 	client      *http.Client
+	mu          sync.RWMutex
 }
 
 // SearchResult represents a single knowledge search result.
@@ -90,7 +92,7 @@ func (ks *KnowledgeSearcher) Search(ctx context.Context, query string) ([]Search
 	if err != nil {
 		return nil, fmt.Errorf("knowledge search: create request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+ks.authToken)
+	req.Header.Set("Authorization", "Bearer "+ks.getAuthToken())
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := ks.client.Do(req)
@@ -114,4 +116,17 @@ func (ks *KnowledgeSearcher) Search(ctx context.Context, query string) ([]Search
 	}
 
 	return envelope.Data, nil
+}
+
+// SetAuthToken updates the bearer token used for knowledge search requests.
+func (ks *KnowledgeSearcher) SetAuthToken(token string) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	ks.authToken = token
+}
+
+func (ks *KnowledgeSearcher) getAuthToken() string {
+	ks.mu.RLock()
+	defer ks.mu.RUnlock()
+	return ks.authToken
 }

--- a/pkg/worker/knowledge/search_test.go
+++ b/pkg/worker/knowledge/search_test.go
@@ -141,3 +141,22 @@ func TestKnowledgeSearcher_InvalidJSON(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode response")
 }
+
+func TestKnowledgeSearcher_SetAuthToken(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(searchResponse{Data: []SearchResult{}})
+	}))
+	defer srv.Close()
+
+	ks := NewKnowledgeSearcher(srv.URL, "old-token", "ws-1")
+	ks.SetAuthToken("new-token")
+
+	_, err := ks.Search(context.Background(), "test")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer new-token", gotAuth)
+}

--- a/pkg/worker/loop.go
+++ b/pkg/worker/loop.go
@@ -22,6 +22,7 @@ import (
 	"github.com/insajin/autopus-adk/pkg/worker/pidlock"
 	"github.com/insajin/autopus-adk/pkg/worker/reaper"
 	"github.com/insajin/autopus-adk/pkg/worker/routing"
+	"github.com/insajin/autopus-adk/pkg/worker/scheduler"
 	"github.com/insajin/autopus-adk/pkg/worker/setup"
 	"github.com/insajin/autopus-adk/pkg/worker/tui"
 )
@@ -65,6 +66,7 @@ type WorkerLoop struct {
 	auditWriter       *audit.RotatingWriter
 	knowledgeSearcher *knowledge.KnowledgeSearcher
 	memorySearcher    *knowledge.MemorySearcher
+	schedulerDisp     *scheduler.Dispatcher
 	semaphore         *parallel.TaskSemaphore
 	worktreeManager   *parallel.WorktreeManager
 	auditLogger       *slogAuditLogger

--- a/pkg/worker/loop_exec.go
+++ b/pkg/worker/loop_exec.go
@@ -89,8 +89,13 @@ func (wl *WorkerLoop) executeWithParallel(ctx context.Context, taskCfg adapter.T
 				log.Printf("[worker] runtime env prepare failed for %s: %v", taskID, envErr)
 			}
 			defer func() {
-				if rmErr := wl.worktreeManager.Remove(wtPath, false); rmErr != nil {
+				removed, rmErr := wl.worktreeManager.RemoveIfClean(wtPath)
+				if rmErr != nil {
 					log.Printf("[worker] worktree remove failed: %v", rmErr)
+					return
+				}
+				if !removed {
+					log.Printf("[worker] preserving dirty worktree for %s: %s", taskID, wtPath)
 				}
 			}()
 		}
@@ -146,8 +151,13 @@ func (wl *WorkerLoop) executePipelineWithParallel(ctx context.Context, taskID, p
 				envVars = runtimeCfg.EnvVars
 			}
 			defer func() {
-				if rmErr := wl.worktreeManager.Remove(wtPath, false); rmErr != nil {
+				removed, rmErr := wl.worktreeManager.RemoveIfClean(wtPath)
+				if rmErr != nil {
 					log.Printf("[worker] worktree remove failed: %v", rmErr)
+					return
+				}
+				if !removed {
+					log.Printf("[worker] preserving dirty worktree for %s: %s", taskID, wtPath)
 				}
 			}()
 		}

--- a/pkg/worker/loop_knowledge.go
+++ b/pkg/worker/loop_knowledge.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/insajin/autopus-adk/pkg/worker/knowledge"
 )
+
+var knowledgeWordCleaner = regexp.MustCompile(`[^a-zA-Z0-9._/-]+`)
 
 func resolveMemoryAgentID(cfg LoopConfig) string {
 	if _, err := uuid.Parse(cfg.MemoryAgentID); err == nil {
@@ -49,7 +52,7 @@ func populateKnowledge(ctx context.Context, searcher *knowledge.KnowledgeSearche
 		return ""
 	}
 
-	results, err := searcher.Search(ctx, description)
+	results, err := searcher.Search(ctx, buildKnowledgeQuery(description))
 	if err != nil {
 		log.Printf("[worker] knowledge search failed: %v", err)
 		return ""
@@ -82,6 +85,41 @@ func populateKnowledge(ctx context.Context, searcher *knowledge.KnowledgeSearche
 		b.WriteByte('\n')
 	}
 	return b.String()
+}
+
+func buildKnowledgeQuery(description string) string {
+	normalized := strings.TrimSpace(strings.Join(strings.Fields(description), " "))
+	if normalized == "" {
+		return ""
+	}
+	if len(normalized) <= 120 {
+		return normalized
+	}
+
+	words := strings.Fields(normalized)
+	keywords := make([]string, 0, 10)
+	seen := make(map[string]struct{}, 10)
+	for _, word := range words {
+		cleaned := strings.ToLower(knowledgeWordCleaner.ReplaceAllString(word, ""))
+		if len(cleaned) < 3 {
+			continue
+		}
+		if _, ok := seen[cleaned]; ok {
+			continue
+		}
+		seen[cleaned] = struct{}{}
+		keywords = append(keywords, cleaned)
+		if len(keywords) == 10 {
+			break
+		}
+	}
+	if len(keywords) == 0 {
+		if len(normalized) > 120 {
+			return normalized[:120]
+		}
+		return normalized
+	}
+	return strings.Join(keywords, " ")
 }
 
 // truncateForMemory extracts a brief learning summary from task output.

--- a/pkg/worker/loop_knowledge_test.go
+++ b/pkg/worker/loop_knowledge_test.go
@@ -87,3 +87,22 @@ func TestTruncateForMemory_ExactLimit(t *testing.T) {
 	got := truncateForMemory(description, output)
 	assert.Len(t, got, 500)
 }
+
+func TestBuildKnowledgeQuery_ShortDescription(t *testing.T) {
+	t.Parallel()
+
+	description := "runtime canary"
+	assert.Equal(t, "runtime canary", buildKnowledgeQuery(description))
+}
+
+func TestBuildKnowledgeQuery_LongDescription_CompressesToKeywords(t *testing.T) {
+	t.Parallel()
+
+	description := "In the current workspace, create a file named runtime-postfix-canary-20260413-2303.md containing exactly three lines: Post-fix canary, 20260413-2303, ok. Do not modify any other files."
+	got := buildKnowledgeQuery(description)
+
+	assert.NotContains(t, got, "exactly three lines")
+	assert.LessOrEqual(t, len(got), 120)
+	assert.Contains(t, got, "runtime-postfix-canary-20260413-2303.md")
+	assert.Contains(t, got, "workspace")
+}

--- a/pkg/worker/loop_lifecycle.go
+++ b/pkg/worker/loop_lifecycle.go
@@ -45,7 +45,7 @@ func (wl *WorkerLoop) startServices(ctx context.Context) {
 				wl.config.CredentialStore,
 				func() { log.Printf("[worker] re-authentication needed") },
 				func(newToken string) {
-					wl.server.SetAuthToken(newToken)
+					wl.updateAuthToken(newToken)
 					log.Printf("[worker] auth token refreshed")
 				},
 			)
@@ -88,6 +88,7 @@ func (wl *WorkerLoop) startServices(ctx context.Context) {
 				log.Printf("[worker] schedule triggered: %s", scheduleID)
 			},
 		)
+		wl.schedulerDisp = d
 		go d.Start(wl.lifecycleCtx)
 	}
 
@@ -137,6 +138,23 @@ func (wl *WorkerLoop) startServices(ctx context.Context) {
 	// @AX:NOTE[AUTO]: magic constant — 30s reaper interval matches reaper.go default; keep in sync if default changes
 	wl.zombieReaper = reaper.New(reaper.Config{Interval: 30 * time.Second})
 	wl.zombieReaper.Start(wl.lifecycleCtx) //nolint:errcheck
+}
+
+func (wl *WorkerLoop) updateAuthToken(token string) {
+	if token == "" {
+		return
+	}
+	wl.config.AuthToken = token
+	wl.server.SetAuthToken(token)
+	if wl.knowledgeSearcher != nil {
+		wl.knowledgeSearcher.SetAuthToken(token)
+	}
+	if wl.memorySearcher != nil {
+		wl.memorySearcher.SetAuthToken(token)
+	}
+	if wl.schedulerDisp != nil {
+		wl.schedulerDisp.SetAuthToken(token)
+	}
 }
 
 // stopServices gracefully stops all lifecycle services.

--- a/pkg/worker/parallel/worktree.go
+++ b/pkg/worker/parallel/worktree.go
@@ -56,6 +56,30 @@ func (m *WorktreeManager) Remove(worktreePath string, force bool) error {
 	return nil
 }
 
+// IsClean reports whether the worktree has no modified or untracked files.
+func (m *WorktreeManager) IsClean(worktreePath string) (bool, error) {
+	cmd := exec.Command("git", "status", "--porcelain", "--untracked-files=normal")
+	cmd.Dir = worktreePath
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("worktree status %s: %s: %w", worktreePath, strings.TrimSpace(string(out)), err)
+	}
+	return strings.TrimSpace(string(out)) == "", nil
+}
+
+// RemoveIfClean removes the worktree only when it has no local changes.
+func (m *WorktreeManager) RemoveIfClean(worktreePath string) (bool, error) {
+	clean, err := m.IsClean(worktreePath)
+	if err != nil {
+		return false, err
+	}
+	if !clean {
+		return false, nil
+	}
+	return true, m.Remove(worktreePath, false)
+}
+
 // List returns all active worktree paths (excluding the main worktree).
 func (m *WorktreeManager) List() ([]string, error) {
 	cmd := exec.Command("git", "-c", "gc.auto=0", "worktree", "list", "--porcelain")

--- a/pkg/worker/parallel/worktree_test.go
+++ b/pkg/worker/parallel/worktree_test.go
@@ -1,6 +1,7 @@
 package parallel
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -127,6 +128,51 @@ func TestNewWorktreeManager(t *testing.T) {
 	m := NewWorktreeManager("/some/path")
 	assert.NotNil(t, m)
 	assert.Equal(t, "/some/path", m.baseDir)
+}
+
+func TestWorktreeManager_IsCleanAndRemoveIfClean(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := realTempDir(t)
+	initGitRepo(t, tmpDir)
+
+	m := NewWorktreeManager(tmpDir)
+	wtPath, err := m.Create("clean-check")
+	require.NoError(t, err)
+
+	clean, err := m.IsClean(wtPath)
+	require.NoError(t, err)
+	assert.True(t, clean)
+
+	removed, err := m.RemoveIfClean(wtPath)
+	require.NoError(t, err)
+	assert.True(t, removed)
+}
+
+func TestWorktreeManager_RemoveIfClean_PreservesDirtyWorktree(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := realTempDir(t)
+	initGitRepo(t, tmpDir)
+
+	m := NewWorktreeManager(tmpDir)
+	wtPath, err := m.Create("dirty-check")
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, "note.txt"), []byte("dirty"), 0o644))
+
+	clean, err := m.IsClean(wtPath)
+	require.NoError(t, err)
+	assert.False(t, clean)
+
+	removed, err := m.RemoveIfClean(wtPath)
+	require.NoError(t, err)
+	assert.False(t, removed)
+
+	_, err = os.Stat(wtPath)
+	require.NoError(t, err)
+
+	require.NoError(t, m.Remove(wtPath, true))
 }
 
 // initGitRepo initializes a bare-minimum git repo with one commit

--- a/pkg/worker/scheduler/dispatcher.go
+++ b/pkg/worker/scheduler/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -18,9 +19,9 @@ const (
 
 // schedule represents a single schedule entry from the backend API.
 type schedule struct {
-	ID             string `json:"id"`
-	CronExpr       string `json:"cron_expression"`
-	TaskPayload    string `json:"task_payload"`
+	ID              string `json:"id"`
+	CronExpr        string `json:"cron_expression"`
+	TaskPayload     string `json:"task_payload"`
 	TargetAgentType string `json:"target_agent_type"`
 }
 
@@ -33,6 +34,7 @@ type Dispatcher struct {
 	lastTrigger map[string]time.Time
 	onTrigger   func(scheduleID, taskPayload string)
 	client      *http.Client
+	mu          sync.RWMutex
 }
 
 // NewDispatcher creates a dispatcher that evaluates cron schedules in the given timezone.
@@ -119,7 +121,7 @@ func (d *Dispatcher) fetchSchedules(ctx context.Context) ([]schedule, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+d.authToken)
+	req.Header.Set("Authorization", "Bearer "+d.getAuthToken())
 
 	resp, err := d.client.Do(req)
 	if err != nil {
@@ -142,4 +144,17 @@ func (d *Dispatcher) fetchSchedules(ctx context.Context) ([]schedule, error) {
 		return nil, fmt.Errorf("decode schedules: %w", err)
 	}
 	return wrapper.Data, nil
+}
+
+// SetAuthToken updates the bearer token used for schedule fetches.
+func (d *Dispatcher) SetAuthToken(token string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.authToken = token
+}
+
+func (d *Dispatcher) getAuthToken() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.authToken
 }

--- a/pkg/worker/scheduler/dispatcher_test.go
+++ b/pkg/worker/scheduler/dispatcher_test.go
@@ -141,6 +141,28 @@ func TestDispatcher_TimezoneHandling(t *testing.T) {
 	assert.True(t, triggered, "should trigger when matching in the configured timezone")
 }
 
+func TestDispatcher_SetAuthToken_UpdatesHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success": true,
+			"data":    []schedule{},
+		})
+	}))
+	defer srv.Close()
+
+	d := NewDispatcher(srv.URL, "old-token", "ws-42", time.UTC, func(string, string) {})
+	d.SetAuthToken("new-token")
+
+	_, err := d.fetchSchedules(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer new-token", gotAuth)
+}
+
 // minuteMatchingCron returns a cron expression that matches the given time's
 // minute, hour, dom, month, and dow.
 func minuteMatchingCron(t time.Time) string {


### PR DESCRIPTION
## 변경 내용
- A2A REST fallback 경로를 production API에 맞게 `/api/worker/tasks/pending`으로 수정했습니다.
- auth token refresh가 transport, scheduler, knowledge, memory 경로까지 전파되도록 정리했습니다.
- Codex adapter에서 불필요한 `resume` 호출과 지원되지 않는 `openai/*` 모델 override를 제거했습니다.
- dirty worktree는 삭제 실패 대신 보존하도록 처리했고 관련 테스트를 보강했습니다.

## 원인
- 오래된 poll endpoint와 토큰 전파 누락으로 운영 401/404가 반복됐습니다.
- worker cleanup과 Codex invocation이 실제 runtime 제약과 맞지 않았습니다.

## 영향
- worker 재연결 이후 실제 task fetch 안정성 개선
- knowledge/memory/scheduler 인증 동기화 개선
- runtime 작업 디렉터리 보존 동작 개선

## 검증
- `go test ./pkg/worker/... -timeout 240s`
