### PR TITLE
워커 재연결 및 git 후조건 fail-closed 강화

### DIFF
--- a/pkg/worker/a2a/server.go
+++ b/pkg/worker/a2a/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	cancel       context.CancelFunc
 	heartbeat    *Heartbeat
 	restPoller   *RESTPoller
+	reconnectMu  sync.Mutex
 }
 
 // toWebSocketURL converts an http/https URL to a ws/wss URL for WebSocket dialing.
@@ -85,10 +86,24 @@ func (s *Server) Start(ctx context.Context) error {
 		return s.transport.Send(msg)
 	}, func() {
 		log.Printf("[a2a] heartbeat timeout — connection may be lost")
+		go func() {
+			if err := s.ReconnectTransport(ctx); err != nil {
+				log.Printf("[a2a] heartbeat reconnect failed: %v", err)
+			}
+		}()
 	})
 	s.heartbeat.Start(ctx)
 
-	card := AgentCard{
+	if err := s.RegisterAgentCard(s.agentCard()); err != nil {
+		return fmt.Errorf("a2a register card: %w", err)
+	}
+
+	go s.messageLoop(ctx)
+	return nil
+}
+
+func (s *Server) agentCard() AgentCard {
+	return AgentCard{
 		Name:                s.config.WorkerName,
 		Description:         "Autopus ADK Worker",
 		URL:                 s.config.BackendURL,
@@ -97,12 +112,6 @@ func (s *Server) Start(ctx context.Context) error {
 		Capabilities:        DefaultCapabilities(),
 		SupportedInputModes: []string{"text"},
 	}
-	if err := s.RegisterAgentCard(card); err != nil {
-		return fmt.Errorf("a2a register card: %w", err)
-	}
-
-	go s.messageLoop(ctx)
-	return nil
 }
 
 // RegisterAgentCard sends the agent card to the backend.
@@ -165,10 +174,25 @@ func (s *Server) SetRESTPoller(p *RESTPoller) {
 
 // ReconnectTransport attempts to reconnect the WebSocket transport.
 func (s *Server) ReconnectTransport(ctx context.Context) error {
+	s.reconnectMu.Lock()
+	defer s.reconnectMu.Unlock()
+
 	if s.transport == nil {
 		return fmt.Errorf("transport not initialized")
 	}
-	return s.transport.Reconnect(ctx)
+	if err := s.transport.Reconnect(ctx); err != nil {
+		return err
+	}
+	if s.heartbeat != nil {
+		s.heartbeat.Ack()
+	}
+	if err := s.RegisterAgentCard(s.agentCard()); err != nil {
+		return fmt.Errorf("re-register agent card: %w", err)
+	}
+	if s.restPoller != nil {
+		s.restPoller.Stop()
+	}
+	return nil
 }
 
 // Close shuts down the server and its transport.

--- a/pkg/worker/a2a/server_dispatch.go
+++ b/pkg/worker/a2a/server_dispatch.go
@@ -32,6 +32,18 @@ func (s *Server) messageLoop(ctx context.Context) {
 			}
 			log.Printf("[a2a] receive error: %v", err)
 
+			if reconnectErr := s.ReconnectTransport(ctx); reconnectErr == nil {
+				backoff = 0
+				if exhaustedFired && s.restPoller != nil {
+					s.restPoller.Stop()
+				}
+				exhaustedFired = false
+				log.Printf("[a2a] transport recovered after receive error")
+				continue
+			} else {
+				log.Printf("[a2a] reconnect attempt after receive error failed: %v", reconnectErr)
+			}
+
 			// Exponential backoff on consecutive errors.
 			if backoff == 0 {
 				backoff = 500 * time.Millisecond

--- a/pkg/worker/a2a/server_error_test.go
+++ b/pkg/worker/a2a/server_error_test.go
@@ -124,7 +124,9 @@ func TestServer_UnknownMethod(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      json.RawMessage(`13`),
 		Method:  MethodCancelTask,
-		Params:  mustMarshal(struct{ TaskID string `json:"task_id"` }{TaskID: "nonexistent"}),
+		Params: mustMarshal(struct {
+			TaskID string `json:"task_id"`
+		}{TaskID: "nonexistent"}),
 	}
 	cancelData, _ := json.Marshal(cancelReq)
 	require.NoError(t, mb.sendMessage(cancelData))
@@ -236,4 +238,32 @@ func TestServer_MessageLoop_BackoffOnReceiveError(t *testing.T) {
 
 	// Verify server can be closed without hanging.
 	require.NoError(t, srv.Close())
+}
+
+func TestServer_MessageLoop_ReconnectsAfterReceiveError(t *testing.T) {
+	mb := newMockBackend()
+	defer mb.close()
+
+	srv := NewServer(ServerConfig{
+		BackendURL: mb.wsURL(),
+		WorkerName: "test-worker",
+		Skills:     []string{"echo"},
+		Handler: func(_ context.Context, _ string, _ json.RawMessage) (*TaskResult, error) {
+			return &TaskResult{}, nil
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	defer srv.Close()
+
+	require.NoError(t, srv.Start(ctx))
+	mb.waitForMessages(t, 1, 3*time.Second) // initial registration
+
+	mb.closeConn()
+
+	msgs := mb.waitForMessages(t, 1, 5*time.Second)
+	var regReq JSONRPCRequest
+	require.NoError(t, json.Unmarshal(msgs[0], &regReq))
+	assert.Equal(t, MethodRegisterCard, regReq.Method)
 }

--- a/pkg/worker/a2a/server_test.go
+++ b/pkg/worker/a2a/server_test.go
@@ -70,6 +70,15 @@ func (mb *mockBackend) sendMessage(msg []byte) error {
 	return mb.conn.WriteMessage(websocket.TextMessage, msg)
 }
 
+func (mb *mockBackend) closeConn() {
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+	if mb.conn != nil {
+		_ = mb.conn.Close()
+		mb.conn = nil
+	}
+}
+
 func (mb *mockBackend) wsURL() string {
 	return "ws" + strings.TrimPrefix(mb.server.URL, "http")
 }
@@ -219,6 +228,35 @@ func TestServer_SendMessage_HandlerError(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resultBytes, &result))
 	assert.Equal(t, StatusFailed, result.Status)
 	assert.Contains(t, result.Error, "handler exploded")
+}
+
+func TestServer_ReconnectTransport_ReRegistersAgentCard(t *testing.T) {
+	mb := newMockBackend()
+	defer mb.close()
+
+	srv := NewServer(ServerConfig{
+		BackendURL: mb.wsURL(),
+		WorkerName: "reconnect-worker",
+		Skills:     []string{"echo"},
+		Handler: func(_ context.Context, _ string, _ json.RawMessage) (*TaskResult, error) {
+			return &TaskResult{}, nil
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	defer srv.Close()
+
+	require.NoError(t, srv.Start(ctx))
+	mb.waitForMessages(t, 1, 3*time.Second) // initial registration
+
+	mb.closeConn()
+	require.NoError(t, srv.ReconnectTransport(ctx))
+
+	msgs := mb.waitForMessages(t, 1, 3*time.Second)
+	var regReq JSONRPCRequest
+	require.NoError(t, json.Unmarshal(msgs[0], &regReq))
+	assert.Equal(t, MethodRegisterCard, regReq.Method)
 }
 
 func TestMergeTaskPayload_InjectsModelAndPipelineMetadata(t *testing.T) {

--- a/pkg/worker/loop_exec.go
+++ b/pkg/worker/loop_exec.go
@@ -59,6 +59,7 @@ type BudgetConfig struct {
 func (wl *WorkerLoop) executeWithParallel(ctx context.Context, taskCfg adapter.TaskConfig, bc *BudgetConfig) (adapter.TaskResult, error) {
 	taskID := taskCfg.TaskID
 	startTime := time.Now()
+	baseline := captureExecutionBaseline(taskCfg.WorkDir)
 
 	// Record task start in the audit log.
 	if wl.auditWriter != nil {
@@ -112,6 +113,16 @@ func (wl *WorkerLoop) executeWithParallel(ctx context.Context, taskCfg adapter.T
 		}
 		return result, err
 	}
+	artifact, verifyErr := verifyExecutionPostconditions(taskCfg.WorkDir, taskCfg.Prompt, baseline)
+	if artifact.Name != "" {
+		result.Artifacts = append(result.Artifacts, artifact)
+	}
+	if verifyErr != nil {
+		if wl.auditWriter != nil {
+			writeResilientAuditEvent(wl.auditWriter, newAuditFailedEvent(taskID, durationMS, taskCfg.ComputerUse), wl.auditLogger)
+		}
+		return result, verifyErr
+	}
 	if wl.auditWriter != nil {
 		writeResilientAuditEvent(wl.auditWriter, newAuditCompletedEvent(taskID, durationMS, result.CostUSD, taskCfg.ComputerUse), wl.auditLogger)
 	}
@@ -164,6 +175,7 @@ func (wl *WorkerLoop) executePipelineWithParallel(ctx context.Context, taskID, p
 	}
 
 	pe := NewPipelineExecutor(wl.config.Provider, wl.config.MCPConfig, workDir)
+	baseline := captureExecutionBaseline(workDir)
 	pe.SetEnvVars(envVars)
 	pe.SetPhaseInstructions(instructions)
 	pe.SetPhasePromptTemplates(promptTemplates)
@@ -178,6 +190,16 @@ func (wl *WorkerLoop) executePipelineWithParallel(ctx context.Context, taskID, p
 			writeResilientAuditEvent(wl.auditWriter, newAuditFailedEvent(taskID, durationMS, false), wl.auditLogger)
 		}
 		return adapter.TaskResult{}, err
+	}
+	artifact, verifyErr := verifyExecutionPostconditions(workDir, prompt, baseline)
+	if artifact.Name != "" {
+		result.Artifacts = append(result.Artifacts, artifact)
+	}
+	if verifyErr != nil {
+		if wl.auditWriter != nil {
+			writeResilientAuditEvent(wl.auditWriter, newAuditFailedEvent(taskID, durationMS, false), wl.auditLogger)
+		}
+		return result, verifyErr
 	}
 	if wl.auditWriter != nil {
 		writeResilientAuditEvent(wl.auditWriter, newAuditCompletedEvent(taskID, durationMS, result.CostUSD, false), wl.auditLogger)

--- a/pkg/worker/parallel/worktree.go
+++ b/pkg/worker/parallel/worktree.go
@@ -2,6 +2,7 @@ package parallel
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -34,6 +35,9 @@ func (m *WorktreeManager) Create(taskID string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("worktree create %s: %s: %w", taskID, strings.TrimSpace(string(out)), err)
+	}
+	if err := m.ensureRuntimeExclude(wtPath); err != nil {
+		return "", err
 	}
 	return wtPath, nil
 }
@@ -106,4 +110,42 @@ func (m *WorktreeManager) List() ([]string, error) {
 // worktreePath returns the filesystem path for a task's worktree.
 func (m *WorktreeManager) worktreePath(taskID string) string {
 	return filepath.Join(m.baseDir, ".worktrees", fmt.Sprintf("worker-%s", taskID))
+}
+
+func (m *WorktreeManager) ensureRuntimeExclude(worktreePath string) error {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = worktreePath
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("resolve git dir for %s: %s: %w", worktreePath, strings.TrimSpace(string(out)), err)
+	}
+
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		return fmt.Errorf("prepare git exclude dir: %w", err)
+	}
+
+	current, err := os.ReadFile(excludePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read git exclude: %w", err)
+	}
+	if strings.Contains(string(current), ".symphony/") {
+		return nil
+	}
+
+	var next strings.Builder
+	next.Write(current)
+	if len(current) > 0 && !strings.HasSuffix(string(current), "\n") {
+		next.WriteByte('\n')
+	}
+	next.WriteString(".symphony/\n")
+
+	if err := os.WriteFile(excludePath, []byte(next.String()), 0o644); err != nil {
+		return fmt.Errorf("write git exclude: %w", err)
+	}
+	return nil
 }

--- a/pkg/worker/parallel/worktree_test.go
+++ b/pkg/worker/parallel/worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,6 +76,33 @@ func TestWorktreeManager_CreateCommandArgs(t *testing.T) {
 	assert.Equal(t, expected, wtPath)
 
 	// Cleanup the worktree.
+	require.NoError(t, m.Remove(wtPath, false))
+}
+
+func TestWorktreeManager_CreateAddsSymphonyExclude(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := realTempDir(t)
+	initGitRepo(t, tmpDir)
+
+	m := NewWorktreeManager(tmpDir)
+	wtPath, err := m.Create("exclude-task")
+	require.NoError(t, err)
+
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = wtPath
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	content, err := os.ReadFile(excludePath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), ".symphony/")
+
 	require.NoError(t, m.Remove(wtPath, false))
 }
 

--- a/pkg/worker/postconditions.go
+++ b/pkg/worker/postconditions.go
@@ -1,0 +1,249 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/worker/adapter"
+)
+
+var (
+	commitIntentPattern  = regexp.MustCompile(`(?i)\bgit\s+commit\b|\bcommit\b`)
+	pushIntentPattern    = regexp.MustCompile(`(?i)\bgit\s+push\b|\bpush\b`)
+	branchIntentPattern  = regexp.MustCompile(`(?i)\bbranch\b`)
+	refsHeadsPattern     = regexp.MustCompile(`refs/heads/([A-Za-z0-9._/-]+)`)
+	branchKeywordPattern = regexp.MustCompile(`(?i)\bbranch\s+([A-Za-z0-9._/-]+)`)
+	originBranchPattern  = regexp.MustCompile(`(?i)\borigin(?:/|\s+)([A-Za-z0-9._/-]+)`)
+	postconditionTimeout = 5 * time.Second
+)
+
+type executionBaseline struct {
+	GitRepo bool
+	HeadSHA string
+	Branch  string
+}
+
+type taskPostconditions struct {
+	CommitRequired bool
+	PushRequired   bool
+	BranchRequired bool
+	Branches       []string
+}
+
+type postconditionCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
+}
+
+type postconditionReport struct {
+	Active   bool                 `json:"active"`
+	Checks   []postconditionCheck `json:"checks,omitempty"`
+	Branches []string             `json:"branches,omitempty"`
+}
+
+func captureExecutionBaseline(workDir string) executionBaseline {
+	headSHA, err := gitOutput(workDir, "rev-parse", "HEAD")
+	if err != nil {
+		return executionBaseline{}
+	}
+	branch, _ := gitOutput(workDir, "branch", "--show-current")
+	return executionBaseline{
+		GitRepo: true,
+		HeadSHA: strings.TrimSpace(headSHA),
+		Branch:  strings.TrimSpace(branch),
+	}
+}
+
+func detectTaskPostconditions(prompt string) taskPostconditions {
+	reqs := taskPostconditions{
+		CommitRequired: commitIntentPattern.MatchString(prompt),
+		PushRequired:   pushIntentPattern.MatchString(prompt),
+		BranchRequired: branchIntentPattern.MatchString(prompt),
+	}
+
+	branches := make(map[string]struct{})
+	for _, pattern := range []*regexp.Regexp{refsHeadsPattern, branchKeywordPattern, originBranchPattern} {
+		matches := pattern.FindAllStringSubmatch(prompt, -1)
+		for _, match := range matches {
+			if len(match) < 2 {
+				continue
+			}
+			branch := sanitizeBranchName(match[1])
+			if branch == "" {
+				continue
+			}
+			branches[branch] = struct{}{}
+		}
+	}
+
+	reqs.Branches = make([]string, 0, len(branches))
+	for branch := range branches {
+		reqs.Branches = append(reqs.Branches, branch)
+	}
+	sort.Strings(reqs.Branches)
+	return reqs
+}
+
+func verifyExecutionPostconditions(workDir, prompt string, baseline executionBaseline) (adapter.Artifact, error) {
+	reqs := detectTaskPostconditions(prompt)
+	if !baseline.GitRepo || (!reqs.CommitRequired && !reqs.PushRequired && !reqs.BranchRequired) {
+		return adapter.Artifact{}, nil
+	}
+
+	report := postconditionReport{
+		Active:   true,
+		Branches: append([]string(nil), reqs.Branches...),
+	}
+
+	currentHead, headErr := gitOutput(workDir, "rev-parse", "HEAD")
+	if reqs.CommitRequired {
+		if headErr != nil {
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "commit",
+				Status: "failed",
+				Detail: headErr.Error(),
+			})
+		} else if strings.TrimSpace(currentHead) == baseline.HeadSHA {
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "commit",
+				Status: "failed",
+				Detail: "HEAD did not advance after execution",
+			})
+		} else {
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "commit",
+				Status: "passed",
+				Detail: strings.TrimSpace(currentHead),
+			})
+		}
+	}
+
+	if reqs.BranchRequired {
+		branches := branchesForVerification(reqs, workDir)
+		if len(branches) == 0 {
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "branch",
+				Status: "failed",
+				Detail: "unable to determine target branch",
+			})
+		}
+		for _, branch := range branches {
+			if err := gitRun(workDir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
+				report.Checks = append(report.Checks, postconditionCheck{
+					Name:   "branch",
+					Status: "failed",
+					Detail: fmt.Sprintf("local branch %q not found", branch),
+				})
+				continue
+			}
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "branch",
+				Status: "passed",
+				Detail: branch,
+			})
+		}
+	}
+
+	if reqs.PushRequired {
+		branches := branchesForVerification(reqs, workDir)
+		if len(branches) == 0 {
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "push",
+				Status: "failed",
+				Detail: "unable to determine pushed branch",
+			})
+		}
+		for _, branch := range branches {
+			if err := gitRun(workDir, "ls-remote", "--exit-code", "--heads", "origin", branch); err != nil {
+				report.Checks = append(report.Checks, postconditionCheck{
+					Name:   "push",
+					Status: "failed",
+					Detail: fmt.Sprintf("remote branch %q not found", branch),
+				})
+				continue
+			}
+			report.Checks = append(report.Checks, postconditionCheck{
+				Name:   "push",
+				Status: "passed",
+				Detail: branch,
+			})
+		}
+	}
+
+	artifact := adapter.Artifact{
+		Name:     "postconditions.json",
+		MimeType: "application/json",
+		Data:     mustMarshalPostconditionReport(report),
+	}
+
+	var failures []string
+	for _, check := range report.Checks {
+		if check.Status == "failed" {
+			failures = append(failures, fmt.Sprintf("%s: %s", check.Name, check.Detail))
+		}
+	}
+	if len(failures) > 0 {
+		return artifact, fmt.Errorf("postcondition failed: %s", strings.Join(failures, "; "))
+	}
+	return artifact, nil
+}
+
+func branchesForVerification(reqs taskPostconditions, workDir string) []string {
+	if len(reqs.Branches) > 0 {
+		return append([]string(nil), reqs.Branches...)
+	}
+	currentBranch, err := gitOutput(workDir, "branch", "--show-current")
+	if err != nil {
+		return nil
+	}
+	currentBranch = sanitizeBranchName(currentBranch)
+	if currentBranch == "" || strings.HasPrefix(currentBranch, "worker-") {
+		return nil
+	}
+	return []string{currentBranch}
+}
+
+func sanitizeBranchName(raw string) string {
+	branch := strings.TrimSpace(raw)
+	branch = strings.Trim(branch, "\"'`.,)")
+	if branch == "" {
+		return ""
+	}
+	if strings.Contains(branch, "..") || strings.HasPrefix(branch, "-") {
+		return ""
+	}
+	return branch
+}
+
+func gitOutput(workDir string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), postconditionTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func gitRun(workDir string, args ...string) error {
+	_, err := gitOutput(workDir, args...)
+	return err
+}
+
+func mustMarshalPostconditionReport(report postconditionReport) string {
+	data, err := json.Marshal(report)
+	if err != nil {
+		return `{"active":true,"checks":[{"name":"marshal","status":"failed","detail":"report serialization failed"}]}`
+	}
+	return string(data)
+}

--- a/pkg/worker/postconditions_test.go
+++ b/pkg/worker/postconditions_test.go
@@ -1,0 +1,82 @@
+package worker
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyExecutionPostconditions_PushBranchMissingFails(t *testing.T) {
+	t.Parallel()
+
+	repo := initGitRepoWithOrigin(t)
+	baseline := captureExecutionBaseline(repo)
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "note.txt"), []byte("change"), 0o644))
+	runGit(t, repo, "checkout", "-b", "autopus-canary-missing")
+	runGit(t, repo, "add", "note.txt")
+	runGit(t, repo, "commit", "-m", "change")
+
+	artifact, err := verifyExecutionPostconditions(repo, "create branch autopus-canary-missing, commit changes, and git push origin autopus-canary-missing", baseline)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote branch")
+	assert.Equal(t, "postconditions.json", artifact.Name)
+}
+
+func TestVerifyExecutionPostconditions_PushBranchExistsPasses(t *testing.T) {
+	t.Parallel()
+
+	repo := initGitRepoWithOrigin(t)
+	baseline := captureExecutionBaseline(repo)
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "note.txt"), []byte("change"), 0o644))
+	runGit(t, repo, "checkout", "-b", "autopus-canary-pass")
+	runGit(t, repo, "add", "note.txt")
+	runGit(t, repo, "commit", "-m", "change")
+	runGit(t, repo, "push", "-u", "origin", "autopus-canary-pass")
+
+	artifact, err := verifyExecutionPostconditions(repo, "create branch autopus-canary-pass, commit changes, and git push origin autopus-canary-pass", baseline)
+	require.NoError(t, err)
+	assert.Equal(t, "postconditions.json", artifact.Name)
+	assert.Contains(t, artifact.Data, "\"status\":\"passed\"")
+}
+
+func initGitRepoWithOrigin(t *testing.T) string {
+	t.Helper()
+
+	repo := t.TempDir()
+	bare := t.TempDir()
+
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.email", "test@test.com")
+	runGit(t, repo, "config", "user.name", "Test")
+	runGit(t, repo, "commit", "--allow-empty", "-m", "init")
+	runGit(t, bare, "init", "--bare")
+	runGit(t, repo, "remote", "add", "origin", bare)
+	defaultBranch := strings.TrimSpace(gitOutputForTest(t, repo, "branch", "--show-current"))
+	runGit(t, repo, "push", "-u", "origin", defaultBranch)
+
+	return repo
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+}
+
+func gitOutputForTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(out))
+	return string(out)
+}


### PR DESCRIPTION
## 변경사항
- WebSocket 재연결 시 A2A agent card 재등록 추가
- receive error 발생 시 서버가 자체 reconnect 하도록 수정
- worktree 내부 `.symphony/` 런타임 디렉터리를 git exclude로 격리
- git commit/push 요청은 후조건 검증 실패 시 completed 대신 실패 처리
- 관련 재현 테스트 추가

## 검증
- go test ./pkg/worker/... -count=1
- go build ./cmd/auto
