### PR TITLE
git push 후조건 브랜치 파서 보정

### DIFF
--- a/pkg/worker/postconditions.go
+++ b/pkg/worker/postconditions.go
@@ -18,8 +18,8 @@ var (
 	pushIntentPattern    = regexp.MustCompile(`(?i)\bgit\s+push\b|\bpush\b`)
 	branchIntentPattern  = regexp.MustCompile(`(?i)\bbranch\b`)
 	refsHeadsPattern     = regexp.MustCompile(`refs/heads/([A-Za-z0-9._/-]+)`)
-	branchKeywordPattern = regexp.MustCompile(`(?i)\bbranch\s+([A-Za-z0-9._/-]+)`)
-	originBranchPattern  = regexp.MustCompile(`(?i)\borigin(?:/|\s+)([A-Za-z0-9._/-]+)`)
+	branchKeywordPattern = regexp.MustCompile(`(?i)\bbranch(?:\s+(?:named|called))?\s+([A-Za-z0-9._/-]*[/-][A-Za-z0-9._/-]+)\b`)
+	originBranchPattern  = regexp.MustCompile(`(?i)\borigin(?:/|\s+)([A-Za-z0-9._/-]*[/-][A-Za-z0-9._/-]+)\b`)
 	postconditionTimeout = 5 * time.Second
 )
 

--- a/pkg/worker/postconditions_test.go
+++ b/pkg/worker/postconditions_test.go
@@ -46,6 +46,13 @@ func TestVerifyExecutionPostconditions_PushBranchExistsPasses(t *testing.T) {
 	assert.Contains(t, artifact.Data, "\"status\":\"passed\"")
 }
 
+func TestDetectTaskPostconditions_IgnoresFillerWords(t *testing.T) {
+	t.Parallel()
+
+	reqs := detectTaskPostconditions("create and switch to a new branch named autopus-canary-20260414-072233 and push the branch to origin")
+	assert.Equal(t, []string{"autopus-canary-20260414-072233"}, reqs.Branches)
+}
+
 func initGitRepoWithOrigin(t *testing.T) string {
 	t.Helper()
 


### PR DESCRIPTION
## 변경사항
- postcondition 브랜치 추출 정규식을 tighten
- `branch named ...` 문장에서 `named`, `to` 같은 filler word를 브랜치로 오인하지 않도록 수정
- 회귀 테스트 추가

## 검증
- go test ./pkg/worker -run "TestVerifyExecutionPostconditions_PushBranchMissingFails|TestVerifyExecutionPostconditions_PushBranchExistsPasses|TestDetectTaskPostconditions_IgnoresFillerWords" -count=1
