### PR TITLE
.symphony 공통 git exclude 적용

### DIFF
--- a/pkg/worker/parallel/worktree.go
+++ b/pkg/worker/parallel/worktree.go
@@ -113,18 +113,18 @@ func (m *WorktreeManager) worktreePath(taskID string) string {
 }
 
 func (m *WorktreeManager) ensureRuntimeExclude(worktreePath string) error {
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = worktreePath
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("resolve git dir for %s: %s: %w", worktreePath, strings.TrimSpace(string(out)), err)
+		return fmt.Errorf("resolve common git dir for %s: %s: %w", worktreePath, strings.TrimSpace(string(out)), err)
 	}
 
-	gitDir := strings.TrimSpace(string(out))
-	if !filepath.IsAbs(gitDir) {
-		gitDir = filepath.Join(worktreePath, gitDir)
+	commonGitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(commonGitDir) {
+		commonGitDir = filepath.Join(worktreePath, commonGitDir)
 	}
-	excludePath := filepath.Join(gitDir, "info", "exclude")
+	excludePath := filepath.Join(commonGitDir, "info", "exclude")
 	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
 		return fmt.Errorf("prepare git exclude dir: %w", err)
 	}

--- a/pkg/worker/parallel/worktree_test.go
+++ b/pkg/worker/parallel/worktree_test.go
@@ -89,7 +89,7 @@ func TestWorktreeManager_CreateAddsSymphonyExclude(t *testing.T) {
 	wtPath, err := m.Create("exclude-task")
 	require.NoError(t, err)
 
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = wtPath
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))


### PR DESCRIPTION
## 변경사항
- worktree별 gitdir이 아니라 common git dir의 `info/exclude`에 `.symphony/`를 기록하도록 수정
- 실제 `git status` 해석 지점과 일치시키는 회귀 테스트 유지

## 검증
- go test ./pkg/worker/parallel -run TestWorktreeManager_CreateAddsSymphonyExclude -count=1
