### PR TITLE
[codex] 워커 Codex Git push 네트워크 우회

### DIFF
--- a/pkg/worker/adapter/codex.go
+++ b/pkg/worker/adapter/codex.go
@@ -22,7 +22,10 @@ func (a *CodexAdapter) Name() string { return "codex" }
 
 // BuildCommand constructs the exec.Cmd for Codex CLI.
 func (a *CodexAdapter) BuildCommand(ctx context.Context, task TaskConfig) *exec.Cmd {
-	args := []string{"exec"}
+	// Worker tasks already run inside an isolated worktree with platform-level
+	// policy enforcement. Git push requires outbound network access, which the
+	// Codex workspace sandbox blocks even in --full-auto mode.
+	args := []string{"exec", "--dangerously-bypass-approvals-and-sandbox"}
 	if task.Prompt != "" {
 		// Read the sensitive task prompt from stdin instead of exposing it
 		// in the process argv where other local processes can inspect it.

--- a/pkg/worker/adapter/codex_test.go
+++ b/pkg/worker/adapter/codex_test.go
@@ -25,6 +25,8 @@ func TestCodexAdapterBuildCommand(t *testing.T) {
 	cmd := a.BuildCommand(context.Background(), task)
 
 	assert.Contains(t, cmd.Args, "exec")
+	assert.Contains(t, cmd.Args, "--dangerously-bypass-approvals-and-sandbox")
+	assert.NotContains(t, cmd.Args, "--full-auto")
 	assert.Contains(t, cmd.Args, "-")
 	assert.NotContains(t, cmd.Args, "fix the bug")
 	assert.Contains(t, cmd.Args, "--json")
@@ -55,6 +57,7 @@ func TestCodexAdapterBuildCommandWithModel(t *testing.T) {
 	}
 
 	cmd := a.BuildCommand(context.Background(), task)
+	assert.Contains(t, cmd.Args, "--dangerously-bypass-approvals-and-sandbox")
 	assert.Contains(t, cmd.Args, "-m")
 	assert.Contains(t, cmd.Args, "o3")
 }
@@ -67,6 +70,7 @@ func TestCodexAdapterBuildCommand_OmitsOpenAIModelOverride(t *testing.T) {
 	}
 
 	cmd := a.BuildCommand(context.Background(), task)
+	assert.Contains(t, cmd.Args, "--dangerously-bypass-approvals-and-sandbox")
 	assert.NotContains(t, cmd.Args, "-m")
 	assert.NotContains(t, cmd.Args, "openai/gpt-5.4")
 }


### PR DESCRIPTION
## 변경 사항
- worker Codex 실행을 danger bypass 모드로 전환
- git push 네트워크 차단 재현 기반 테스트 반영

## 검증
- go test ./pkg/worker/adapter -run 'TestCodexAdapterBuildCommand|TestCodexAdapterBuildCommandWithModel|TestCodexAdapterBuildCommand_OmitsOpenAIModelOverride|TestCodexAdapterBuildCommandWithSession' -count=1\n- go test ./pkg/worker/... -count=1\n- go build ./cmd/auto\n\n## 근본 원인\n- worker runtime의 Codex sandbox가 GitHub remote push 네트워크를 차단해 commit 후 push가 실패함