### PR TITLE
Codex 워커 동시성 안정화와 output artifact 보강

### DIFF
--- a/internal/cli/worker_setup_wizard.go
+++ b/internal/cli/worker_setup_wizard.go
@@ -252,7 +252,7 @@ func stepSaveAndCheckProviders(cmd *cobra.Command, backendURL, token string, ws 
 		WorkDir:           workDir,
 		WorktreeIsolation: true,
 		KnowledgeDir:      workDir,
-		Concurrency:       3,
+		Concurrency:       1,
 	}
 
 	fmt.Fprintln(out, "  ✓ 자동 knowledge file sync는 더 이상 설정하지 않습니다")

--- a/internal/cli/worker_setup_wizard_test.go
+++ b/internal/cli/worker_setup_wizard_test.go
@@ -84,4 +84,5 @@ func TestStepSaveAndCheckProviders_UsesJWTForWorkerAndMCPSkipsBridge(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, "ws-123", workerCfg.WorkspaceID)
 	assert.Equal(t, "memory-agent-1", workerCfg.MemoryAgentID)
+	assert.Equal(t, 1, workerCfg.Concurrency)
 }

--- a/internal/cli/worker_start.go
+++ b/internal/cli/worker_start.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	worker "github.com/insajin/autopus-adk/pkg/worker"
@@ -47,6 +48,11 @@ func runWorkerForeground() error {
 
 	log.Printf("[worker] starting: provider=%s workspace=%s backend=%s",
 		providerName, cfg.WorkspaceID, cfg.BackendURL)
+	effectiveConcurrency := effectiveWorkerConcurrency(providerName, cfg.Concurrency)
+	if effectiveConcurrency != cfg.Concurrency {
+		log.Printf("[worker] provider=%s clamps concurrency from %d to %d for stable task execution",
+			providerName, cfg.Concurrency, effectiveConcurrency)
+	}
 
 	workDir := cfg.WorkDir
 	if workDir == "" {
@@ -65,8 +71,8 @@ func runWorkerForeground() error {
 		CredentialsPath:   setup.DefaultCredentialsPath(),
 		CredentialStore:   credStore,
 		WorkspaceID:       cfg.WorkspaceID,
-		MaxConcurrency:    cfg.Concurrency,
-		WorktreeIsolation: cfg.WorktreeIsolation || cfg.Concurrency > 1,
+		MaxConcurrency:    effectiveConcurrency,
+		WorktreeIsolation: cfg.WorktreeIsolation || effectiveConcurrency > 1,
 		KnowledgeSync:     true, // enable backend knowledge context when WorkspaceID is set
 		KnowledgeDir:      cfg.KnowledgeDir,
 	}
@@ -119,4 +125,11 @@ func resolveProviderAdapter(name string) (adapter.ProviderAdapter, error) {
 	reg.Register(&adapter.CodexAdapter{})
 	reg.Register(&adapter.GeminiAdapter{})
 	return reg.Get(name)
+}
+
+func effectiveWorkerConcurrency(providerName string, requested int) int {
+	if strings.EqualFold(providerName, "codex") && requested > 1 {
+		return 1
+	}
+	return requested
 }

--- a/internal/cli/worker_start_test.go
+++ b/internal/cli/worker_start_test.go
@@ -27,6 +27,32 @@ func TestResolveProvider_FallsBackToFirstConfiguredWhenNoneAuthenticated(t *test
 	assert.Equal(t, "claude", got)
 }
 
+func TestEffectiveWorkerConcurrency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		providerName string
+		requested    int
+		expected     int
+	}{
+		{name: "codex clamps parallel requests", providerName: "codex", requested: 3, expected: 1},
+		{name: "codex leaves sequential unchanged", providerName: "codex", requested: 1, expected: 1},
+		{name: "other providers keep configured concurrency", providerName: "claude", requested: 3, expected: 3},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := effectiveWorkerConcurrency(tc.providerName, tc.requested); got != tc.expected {
+				t.Fatalf("effectiveWorkerConcurrency(%q, %d) = %d, want %d",
+					tc.providerName, tc.requested, got, tc.expected)
+			}
+		})
+	}
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/pkg/worker/loop.go
+++ b/pkg/worker/loop.go
@@ -240,6 +240,7 @@ func (wl *WorkerLoop) handleTask(ctx context.Context, taskID string, payload jso
 	}
 
 	log.Printf("[worker] task %s completed: cost=$%.4f duration=%dms", taskID, result.CostUSD, result.DurationMS)
+	result.Artifacts = ensureOutputArtifact(result.Output, result.Artifacts)
 
 	// Memory write-back: record task learnings (SPEC-KHINT-001 REQ-005).
 	if wl.memorySearcher != nil && memoryAgentID != "" && result.Output != "" {
@@ -315,4 +316,20 @@ func convertArtifacts(src []adapter.Artifact) []a2a.Artifact {
 		}
 	}
 	return out
+}
+
+func ensureOutputArtifact(output string, artifacts []adapter.Artifact) []adapter.Artifact {
+	if strings.TrimSpace(output) == "" {
+		return artifacts
+	}
+	for _, artifact := range artifacts {
+		if artifact.Name == "output" {
+			return artifacts
+		}
+	}
+	return append([]adapter.Artifact{{
+		Name:     "output",
+		MimeType: "text/plain",
+		Data:     output,
+	}}, artifacts...)
 }

--- a/pkg/worker/loop_test.go
+++ b/pkg/worker/loop_test.go
@@ -34,6 +34,26 @@ func TestConvertArtifacts_Multiple(t *testing.T) {
 	assert.Equal(t, "{}", result[1].Data)
 }
 
+func TestEnsureOutputArtifact_AddsOutputArtifactFirst(t *testing.T) {
+	artifacts := ensureOutputArtifact("worker summary", []adapter.Artifact{
+		{Name: "notes.md", MimeType: "text/markdown", Data: "# notes"},
+	})
+
+	require.Len(t, artifacts, 2)
+	assert.Equal(t, "output", artifacts[0].Name)
+	assert.Equal(t, "worker summary", artifacts[0].Data)
+	assert.Equal(t, "notes.md", artifacts[1].Name)
+}
+
+func TestEnsureOutputArtifact_DoesNotDuplicateExistingOutput(t *testing.T) {
+	artifacts := ensureOutputArtifact("worker summary", []adapter.Artifact{
+		{Name: "output", MimeType: "text/plain", Data: "existing summary"},
+	})
+
+	require.Len(t, artifacts, 1)
+	assert.Equal(t, "existing summary", artifacts[0].Data)
+}
+
 func TestNewWorkerLoop(t *testing.T) {
 	cfg := LoopConfig{
 		BackendURL: "http://localhost:8080",
@@ -247,6 +267,9 @@ func TestHandleTask_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, "completed", string(result.Status))
+	require.Len(t, result.Artifacts, 1)
+	assert.Equal(t, "output", result.Artifacts[0].Name)
+	assert.Equal(t, "done", result.Artifacts[0].Data)
 }
 
 func TestHandleTask_InvalidPayload(t *testing.T) {


### PR DESCRIPTION
## 요약
- codex worker는 runtime에서 concurrency를 1로 clamp해서 병렬 실행 타임아웃을 방지
- 새 worker setup 기본 concurrency를 1로 보수화
- A2A 완료 결과에 output artifact를 항상 포함하도록 보강

## 검증
- go test ./internal/cli -run "Test(StepSaveAndCheckProviders_UsesJWTForWorkerAndMCPSkipsBridge|ResolveProvider_(PrefersAuthenticatedConfiguredProvider|FallsBackToFirstConfiguredWhenNoneAuthenticated)|EffectiveWorkerConcurrency)" -count=1
- go test ./pkg/worker/... -run "Test(EnsureOutputArtifact_AddsOutputArtifactFirst|EnsureOutputArtifact_DoesNotDuplicateExistingOutput|HandleTask_HappyPath)" -count=1