### PR TITLE
워커 큐 대기 timeout 분리와 직렬 실행 보강

### DIFF
--- a/pkg/worker/loop.go
+++ b/pkg/worker/loop.go
@@ -96,6 +96,17 @@ func NewWorkerLoop(config LoopConfig) *WorkerLoop {
 	return wl
 }
 
+func (wl *WorkerLoop) configureExecutionConcurrency() {
+	concurrencyLimit := wl.config.MaxConcurrency
+	if concurrencyLimit <= 1 {
+		concurrencyLimit = 1
+	}
+	wl.semaphore = parallel.NewTaskSemaphore(concurrencyLimit)
+	if wl.config.WorktreeIsolation && concurrencyLimit > 1 {
+		wl.worktreeManager = parallel.NewWorktreeManager(wl.config.WorkDir)
+	}
+}
+
 // Start connects to the backend and begins processing tasks.
 // @AX:ANCHOR[AUTO]: public lifecycle entry point — Start/Close are the primary WorkerLoop API; callers (CLI, tests) depend on error contract
 func (wl *WorkerLoop) Start(ctx context.Context) error {
@@ -114,14 +125,7 @@ func (wl *WorkerLoop) Start(ctx context.Context) error {
 	}
 	wl.startServices(ctx)
 
-	// Initialize parallel execution components if concurrency limit is configured.
-	// @AX:NOTE[AUTO]: magic constant — MaxConcurrency threshold 1 means sequential; 0 is treated same as 1 (no semaphore)
-	if wl.config.MaxConcurrency > 1 {
-		wl.semaphore = parallel.NewTaskSemaphore(wl.config.MaxConcurrency)
-		if wl.config.WorktreeIsolation {
-			wl.worktreeManager = parallel.NewWorktreeManager(wl.config.WorkDir)
-		}
-	}
+	wl.configureExecutionConcurrency()
 
 	return nil
 }

--- a/pkg/worker/loop_exec.go
+++ b/pkg/worker/loop_exec.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -17,6 +18,63 @@ import (
 	"github.com/insajin/autopus-adk/pkg/worker/security"
 	"github.com/insajin/autopus-adk/pkg/worker/stream"
 )
+
+func (wl *WorkerLoop) detachedTaskContext(parent context.Context) (context.Context, context.CancelFunc) {
+	base := context.Background()
+	if parent != nil {
+		base = context.WithoutCancel(parent)
+	}
+	ctx, cancel := context.WithCancel(base)
+
+	if wl.lifecycleCtx != nil {
+		go func() {
+			select {
+			case <-wl.lifecycleCtx.Done():
+				cancel()
+			case <-ctx.Done():
+			}
+		}()
+	}
+	if parent != nil {
+		go func() {
+			select {
+			case <-parent.Done():
+				if errors.Is(parent.Err(), context.Canceled) {
+					cancel()
+				}
+			case <-ctx.Done():
+			}
+		}()
+	}
+
+	return ctx, cancel
+}
+
+func (wl *WorkerLoop) executionContext(parent context.Context, taskID string) (context.Context, context.CancelFunc) {
+	baseCtx, baseCancel := wl.detachedTaskContext(parent)
+	timeout := wl.taskExecutionTimeout(taskID)
+	if timeout <= 0 {
+		return baseCtx, baseCancel
+	}
+
+	execCtx, timeoutCancel := context.WithTimeout(baseCtx, timeout)
+	return execCtx, func() {
+		timeoutCancel()
+		baseCancel()
+	}
+}
+
+func (wl *WorkerLoop) taskExecutionTimeout(taskID string) time.Duration {
+	if strings.TrimSpace(taskID) == "" {
+		return 0
+	}
+
+	policy, err := security.NewPolicyCache().Read(taskID)
+	if err != nil || policy == nil || policy.TimeoutSec <= 0 {
+		return 0
+	}
+	return time.Duration(policy.TimeoutSec) * time.Second
+}
 
 // StdinWriter wraps an io.WriteCloser to keep the stdin pipe open
 // after the initial prompt is written. This enables mid-session
@@ -69,7 +127,9 @@ func (wl *WorkerLoop) executeWithParallel(ctx context.Context, taskCfg adapter.T
 	// Acquire a semaphore slot when parallel execution is configured.
 	// This blocks until a slot is available or ctx is cancelled.
 	if wl.semaphore != nil {
-		if err := wl.semaphore.Acquire(ctx); err != nil {
+		acquireCtx, cancelAcquire := wl.detachedTaskContext(ctx)
+		defer cancelAcquire()
+		if err := wl.semaphore.Acquire(acquireCtx); err != nil {
 			return adapter.TaskResult{}, fmt.Errorf("acquire semaphore: %w", err)
 		}
 		defer wl.semaphore.Release()
@@ -103,7 +163,9 @@ func (wl *WorkerLoop) executeWithParallel(ctx context.Context, taskCfg adapter.T
 	}
 
 	// Delegate to the core subprocess executor.
-	result, err := wl.executeWithBudget(ctx, taskCfg, bc)
+	execCtx, cancelExec := wl.executionContext(ctx, taskID)
+	defer cancelExec()
+	result, err := wl.executeWithBudget(execCtx, taskCfg, bc)
 	durationMS := time.Since(startTime).Milliseconds()
 
 	// Record completion or failure in the audit log.
@@ -138,7 +200,9 @@ func (wl *WorkerLoop) executePipelineWithParallel(ctx context.Context, taskID, p
 	}
 
 	if wl.semaphore != nil {
-		if err := wl.semaphore.Acquire(ctx); err != nil {
+		acquireCtx, cancelAcquire := wl.detachedTaskContext(ctx)
+		defer cancelAcquire()
+		if err := wl.semaphore.Acquire(acquireCtx); err != nil {
 			return adapter.TaskResult{}, fmt.Errorf("acquire semaphore: %w", err)
 		}
 		defer wl.semaphore.Release()
@@ -182,7 +246,9 @@ func (wl *WorkerLoop) executePipelineWithParallel(ctx context.Context, taskID, p
 	if bc != nil && bc.Budget.Limit > 0 {
 		pe.SetIterationBudget(bc.Budget)
 	}
-	result, err := pe.ExecuteWithPlan(ctx, taskID, prompt, model, phases)
+	execCtx, cancelExec := wl.executionContext(ctx, taskID)
+	defer cancelExec()
+	result, err := pe.ExecuteWithPlan(execCtx, taskID, prompt, model, phases)
 	durationMS := time.Since(startTime).Milliseconds()
 
 	if err != nil {

--- a/pkg/worker/loop_test.go
+++ b/pkg/worker/loop_test.go
@@ -7,10 +7,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/insajin/autopus-adk/pkg/worker/a2a"
 	"github.com/insajin/autopus-adk/pkg/worker/adapter"
 	"github.com/insajin/autopus-adk/pkg/worker/budget"
+	"github.com/insajin/autopus-adk/pkg/worker/security"
 	"github.com/insajin/autopus-adk/pkg/worker/routing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,6 +67,81 @@ func TestNewWorkerLoop(t *testing.T) {
 	wl := NewWorkerLoop(cfg)
 	require.NotNil(t, wl)
 	assert.Equal(t, "test-worker", wl.config.WorkerName)
+}
+
+func TestConfigureExecutionConcurrency_SequentialStillInitializesSemaphore(t *testing.T) {
+	wl := NewWorkerLoop(LoopConfig{
+		Provider:       adapter.NewClaudeAdapter(),
+		WorkDir:        t.TempDir(),
+		MaxConcurrency: 1,
+	})
+
+	wl.configureExecutionConcurrency()
+
+	require.NotNil(t, wl.semaphore)
+	assert.Equal(t, 1, wl.semaphore.Limit())
+	assert.Nil(t, wl.worktreeManager)
+}
+
+func TestConfigureExecutionConcurrency_ParallelEnablesWorktreeIsolation(t *testing.T) {
+	wl := NewWorkerLoop(LoopConfig{
+		Provider:          adapter.NewClaudeAdapter(),
+		WorkDir:           t.TempDir(),
+		MaxConcurrency:    3,
+		WorktreeIsolation: true,
+	})
+
+	wl.configureExecutionConcurrency()
+
+	require.NotNil(t, wl.semaphore)
+	assert.Equal(t, 3, wl.semaphore.Limit())
+	require.NotNil(t, wl.worktreeManager)
+}
+
+func TestDetachedTaskContext_IgnoresParentDeadline(t *testing.T) {
+	wl := NewWorkerLoop(LoopConfig{Provider: adapter.NewClaudeAdapter()})
+
+	parent, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	taskCtx, taskCancel := wl.detachedTaskContext(parent)
+	defer taskCancel()
+
+	time.Sleep(40 * time.Millisecond)
+	require.ErrorIs(t, parent.Err(), context.DeadlineExceeded)
+	select {
+	case <-taskCtx.Done():
+		t.Fatal("detached task context should ignore parent deadline")
+	default:
+	}
+}
+
+func TestDetachedTaskContext_PropagatesExplicitCancel(t *testing.T) {
+	wl := NewWorkerLoop(LoopConfig{Provider: adapter.NewClaudeAdapter()})
+
+	parent, cancel := context.WithCancel(context.Background())
+	taskCtx, taskCancel := wl.detachedTaskContext(parent)
+	defer taskCancel()
+
+	cancel()
+
+	select {
+	case <-taskCtx.Done():
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("detached task context should honor explicit cancellation")
+	}
+}
+
+func TestTaskExecutionTimeout_ReadsCachedPolicy(t *testing.T) {
+	wl := NewWorkerLoop(LoopConfig{Provider: adapter.NewClaudeAdapter()})
+	cache := security.NewPolicyCache()
+	taskID := "loop-timeout-test"
+	require.NoError(t, cache.Write(taskID, security.SecurityPolicy{TimeoutSec: 123}))
+	t.Cleanup(func() { cache.Delete(taskID) })
+
+	timeout := wl.taskExecutionTimeout(taskID)
+
+	assert.Equal(t, 123*time.Second, timeout)
 }
 
 // --- Mock adapter for integration tests ---


### PR DESCRIPTION
## 요약
- MaxConcurrency=1이어도 semaphore를 초기화해 실제 직렬 실행을 보장
- queued task가 semaphore 대기 중 parent deadline에 소모되지 않도록 detached task context 도입
- 실제 실행 timeout은 cached SecurityPolicy.TimeoutSec 기준으로 재적용

## 검증
- go test ./pkg/worker -run "Test(EnsureOutputArtifact_AddsOutputArtifactFirst|EnsureOutputArtifact_DoesNotDuplicateExistingOutput|NewWorkerLoop|ConfigureExecutionConcurrency_SequentialStillInitializesSemaphore|ConfigureExecutionConcurrency_ParallelEnablesWorktreeIsolation|DetachedTaskContext_IgnoresParentDeadline|DetachedTaskContext_PropagatesExplicitCancel|TaskExecutionTimeout_ReadsCachedPolicy|HandleTask_HappyPath)" -count=1