### PR TITLE
fix(worker): 스캐너 한도와 큐 타임아웃 정렬

### DIFF
--- a/pkg/worker/loop_deadline.go
+++ b/pkg/worker/loop_deadline.go
@@ -1,0 +1,22 @@
+package worker
+
+import (
+	"os"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/worker/security"
+)
+
+func (wl *WorkerLoop) taskExecutionDeadline(taskID string) (time.Time, bool) {
+	timeout := wl.taskExecutionTimeout(taskID)
+	if timeout <= 0 {
+		return time.Time{}, false
+	}
+
+	cache := security.NewPolicyCache()
+	info, err := os.Stat(cache.PolicyPath(taskID))
+	if err != nil {
+		return time.Now().Add(timeout), true
+	}
+	return info.ModTime().Add(timeout), true
+}

--- a/pkg/worker/loop_exec.go
+++ b/pkg/worker/loop_exec.go
@@ -47,12 +47,12 @@ func (wl *WorkerLoop) detachedTaskContext(parent context.Context) (context.Conte
 
 func (wl *WorkerLoop) executionContext(parent context.Context, taskID string) (context.Context, context.CancelFunc) {
 	baseCtx, baseCancel := wl.detachedTaskContext(parent)
-	timeout := wl.taskExecutionTimeout(taskID)
-	if timeout <= 0 {
+	deadline, ok := wl.taskExecutionDeadline(taskID)
+	if !ok {
 		return baseCtx, baseCancel
 	}
 
-	execCtx, timeoutCancel := context.WithTimeout(baseCtx, timeout)
+	execCtx, timeoutCancel := context.WithDeadline(baseCtx, deadline)
 	return execCtx, func() {
 		timeoutCancel()
 		baseCancel()
@@ -122,7 +122,7 @@ func (wl *WorkerLoop) executeWithParallel(ctx context.Context, taskCfg adapter.T
 	// Acquire a semaphore slot when parallel execution is configured.
 	// This blocks until a slot is available or ctx is cancelled.
 	if wl.semaphore != nil {
-		acquireCtx, cancelAcquire := wl.detachedTaskContext(ctx)
+		acquireCtx, cancelAcquire := wl.executionContext(ctx, taskID)
 		defer cancelAcquire()
 		if err := wl.semaphore.Acquire(acquireCtx); err != nil {
 			return adapter.TaskResult{}, fmt.Errorf("acquire semaphore: %w", err)
@@ -195,7 +195,7 @@ func (wl *WorkerLoop) executePipelineWithParallel(ctx context.Context, taskID, p
 	}
 
 	if wl.semaphore != nil {
-		acquireCtx, cancelAcquire := wl.detachedTaskContext(ctx)
+		acquireCtx, cancelAcquire := wl.executionContext(ctx, taskID)
 		defer cancelAcquire()
 		if err := wl.semaphore.Acquire(acquireCtx); err != nil {
 			return adapter.TaskResult{}, fmt.Errorf("acquire semaphore: %w", err)

--- a/pkg/worker/loop_runtime_fix_test.go
+++ b/pkg/worker/loop_runtime_fix_test.go
@@ -1,0 +1,75 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/insajin/autopus-adk/pkg/worker/adapter"
+	"github.com/insajin/autopus-adk/pkg/worker/security"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionContext_UsesPolicyFileModTimeDeadline(t *testing.T) {
+	wl := NewWorkerLoop(LoopConfig{Provider: adapter.NewClaudeAdapter()})
+	cache := security.NewPolicyCache()
+	taskID := "expired-deadline-task"
+	require.NoError(t, cache.Write(taskID, security.SecurityPolicy{TimeoutSec: 1}))
+	t.Cleanup(func() { cache.Delete(taskID) })
+
+	expiredAt := time.Now().Add(-2 * time.Second)
+	require.NoError(t, os.Chtimes(cache.PolicyPath(taskID), expiredAt, expiredAt))
+
+	ctx, cancel := wl.executionContext(context.Background(), taskID)
+	defer cancel()
+
+	<-ctx.Done()
+	require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+}
+
+func TestExecuteWithParallel_DoesNotStartExpiredQueuedTask(t *testing.T) {
+	mock := &mockAdapter{name: "mock", script: `head -c0; echo '{"type":"result","output":"should not run"}'`}
+	wl := NewWorkerLoop(LoopConfig{
+		Provider:       mock,
+		WorkDir:        t.TempDir(),
+		MaxConcurrency: 1,
+	})
+	wl.configureExecutionConcurrency()
+
+	cache := security.NewPolicyCache()
+	taskID := "expired-queued-task"
+	require.NoError(t, cache.Write(taskID, security.SecurityPolicy{TimeoutSec: 1}))
+	t.Cleanup(func() { cache.Delete(taskID) })
+
+	expiredAt := time.Now().Add(-2 * time.Second)
+	require.NoError(t, os.Chtimes(cache.PolicyPath(taskID), expiredAt, expiredAt))
+
+	result, err := wl.executeWithParallel(context.Background(), adapter.TaskConfig{
+		TaskID:  taskID,
+		Prompt:  "do work",
+		WorkDir: t.TempDir(),
+	}, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "acquire semaphore")
+	assert.Empty(t, result.Output)
+	assert.Len(t, mock.calls, 0)
+}
+
+func TestParseStreamWithBudget_AllowsLargeResultLine(t *testing.T) {
+	largeOutput := strings.Repeat("a", 128*1024)
+	payload := fmt.Sprintf("{\"type\":\"result\",\"output\":\"%s\"}\n", largeOutput)
+	mock := &mockAdapter{name: "mock"}
+	wl := &WorkerLoop{
+		config: LoopConfig{Provider: mock},
+	}
+
+	result, err := wl.parseStream(strings.NewReader(payload), "large-line-task")
+
+	require.NoError(t, err)
+	assert.Len(t, result.Output, len(largeOutput))
+}

--- a/pkg/worker/loop_subprocess.go
+++ b/pkg/worker/loop_subprocess.go
@@ -17,6 +17,8 @@ import (
 	"github.com/insajin/autopus-adk/pkg/worker/stream"
 )
 
+const maxSubprocessLineBytes = 8 * 1024 * 1024
+
 func prepareSymphonyWorkspace(workDir, prompt string) error {
 	if !strings.Contains(prompt, ".symphony/prompt.md") {
 		return nil
@@ -151,6 +153,7 @@ func (wl *WorkerLoop) parseStream(r io.Reader, taskID string) (adapter.TaskResul
 
 func (wl *WorkerLoop) parseStreamWithBudget(r io.Reader, taskID string, sw *StdinWriter, bc *BudgetConfig) (adapter.TaskResult, error) {
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxSubprocessLineBytes)
 	var lastResult adapter.TaskResult
 	hasResult := false
 


### PR DESCRIPTION
## 변경 사항
- subprocess scanner 최대 토큰 크기 상향
- policy file modtime 기준 absolute deadline 적용
- queue wait에도 동일 deadline 반영
- 관련 회귀 테스트 추가

## 검증
- go test ./pkg/worker -run 'Test(ExecutionContext_UsesPolicyFileModTimeDeadline|ExecuteWithParallel_DoesNotStartExpiredQueuedTask|ParseStreamWithBudget_AllowsLargeResultLine|ExecuteSubprocess_ContextCancelKillsProcessGroup|EnsureOutputArtifact_AddsOutputArtifactFirst|EnsureOutputArtifact_DoesNotDuplicateExistingOutput|NewWorkerLoop|ConfigureExecutionConcurrency_SequentialStillInitializesSemaphore|ConfigureExecutionConcurrency_ParallelEnablesWorktreeIsolation|DetachedTaskContext_IgnoresParentDeadline|DetachedTaskContext_PropagatesExplicitCancel|TaskExecutionTimeout_ReadsCachedPolicy|ExecuteSubprocess_HappyPath)' -count=1\n- go build -o ./auto ./cmd/auto