### PR TITLE
fix(spec): persist fail-fast + status 역행 가드 (#38)

### DIFF
--- a/internal/cli/spec_review.go
+++ b/internal/cli/spec_review.go
@@ -142,12 +142,16 @@ func runSpecReview(ctx context.Context, specID, strategy string, timeout int) er
 			merged.Findings = spec.ApplyScopeLock(merged.Findings, priorFindings, spec.ReviewModeVerify)
 		}
 
-		// Persist findings and review
+		// Persist findings and review. A mid-pipeline write failure (e.g. the
+		// SPEC directory vanished between resolve and persist) must abort.
+		// Silent continuation was the enabling condition for issue #38 —
+		// the CLI printed "판정: PASS" while leaving the on-disk state
+		// inconsistent and allowing a subsequent run to corrupt unrelated SPECs.
 		if persistErr := spec.PersistFindings(specDir, merged.Findings); persistErr != nil {
-			fmt.Fprintf(os.Stderr, "findings 저장 실패: %v\n", persistErr)
+			return fmt.Errorf("review findings 저장 실패 (SPEC: %s, revision: %d): %w", specID, revision, persistErr)
 		}
 		if persistErr := spec.PersistReview(specDir, merged); persistErr != nil {
-			fmt.Fprintf(os.Stderr, "review.md 저장 실패: %v\n", persistErr)
+			return fmt.Errorf("review.md 저장 실패 (SPEC: %s, revision: %d): %w", specID, revision, persistErr)
 		}
 
 		finalResult = merged
@@ -175,7 +179,7 @@ func runSpecReview(ctx context.Context, specID, strategy string, timeout int) er
 	// Output final result
 	if finalResult != nil {
 		if persistErr := syncReviewedSpecStatus(specDir, finalResult); persistErr != nil {
-			fmt.Fprintf(os.Stderr, "SPEC 상태 업데이트 실패: %v\n", persistErr)
+			return fmt.Errorf("SPEC 상태 업데이트 실패 (SPEC: %s): %w", specID, persistErr)
 		}
 		fmt.Printf("SPEC 리뷰 완료: %s\n", specID)
 		fmt.Printf("판정: %s\n", finalResult.Verdict)

--- a/internal/cli/spec_review_runtime.go
+++ b/internal/cli/spec_review_runtime.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/insajin/autopus-adk/pkg/orchestra"
 	"github.com/insajin/autopus-adk/pkg/spec"
@@ -12,6 +14,14 @@ var (
 	specReviewBuildProviders = buildReviewProviders
 )
 
+// shippedStatuses lists spec statuses that represent work already delivered.
+// A PASS verdict from a fresh review must never silently regress these back
+// to `approved` (issue #38).
+var shippedStatuses = map[string]struct{}{
+	"completed":   {},
+	"implemented": {},
+}
+
 func syncReviewedSpecStatus(specDir string, result *spec.ReviewResult) error {
 	if result == nil {
 		return nil
@@ -19,6 +29,17 @@ func syncReviewedSpecStatus(specDir string, result *spec.ReviewResult) error {
 	if result.Verdict != spec.VerdictPass || hasActiveFindings(result.Findings) {
 		return nil
 	}
+
+	// Guard against status regression: a PASS review on a SPEC that is
+	// already completed/implemented must not rewrite its status.
+	doc, err := spec.Load(specDir)
+	if err != nil {
+		return fmt.Errorf("status gate: load spec: %w", err)
+	}
+	if _, shipped := shippedStatuses[strings.ToLower(doc.Status)]; shipped {
+		return nil
+	}
+
 	return spec.UpdateStatus(specDir, "approved")
 }
 

--- a/internal/cli/spec_review_test.go
+++ b/internal/cli/spec_review_test.go
@@ -175,6 +175,69 @@ func TestRunSpecReview_ReviseDoesNotApproveSpec(t *testing.T) {
 	assert.GreaterOrEqual(t, callCount, 1)
 }
 
+// Regression guard for GitHub issue #38.
+// A subsequent review on a SPEC that is already `completed` (or `implemented`)
+// MUST NOT silently downgrade its status to `approved`. Re-review of shipped
+// work must be an explicit user action, not a side effect of an exploratory
+// review pass.
+func TestRunSpecReview_RefusesToRegressCompletedStatus(t *testing.T) {
+	dir := t.TempDir()
+	specDir := scaffoldReviewSpec(t, dir, "SPEC-REVIEW-REGRESS-001")
+	require.NoError(t, spec.UpdateStatus(specDir, "completed"))
+	setFakeProviderOnPath(t, dir, "claude")
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(dir))
+
+	origRunner := specReviewRunOrchestra
+	specReviewRunOrchestra = func(_ context.Context, _ orchestra.OrchestraConfig) (*orchestra.OrchestraResult, error) {
+		return &orchestra.OrchestraResult{Responses: []orchestra.ProviderResponse{{Provider: "claude", Output: "VERDICT: PASS"}}}, nil
+	}
+	defer func() { specReviewRunOrchestra = origRunner }()
+
+	require.NoError(t, runSpecReview(context.Background(), "SPEC-REVIEW-REGRESS-001", "consensus", 10))
+
+	doc, err := spec.Load(specDir)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", doc.Status, "completed SPEC must not be silently regressed to approved")
+}
+
+// Regression guard for GitHub issue #38.
+// When PersistFindings or PersistReview fails mid-pipeline (e.g. the SPEC
+// directory disappeared between resolution and persistence), the CLI must
+// fail fast instead of continuing through syncReviewedSpecStatus. Silent
+// continuation was the enabling condition for the observed data corruption.
+func TestRunSpecReview_PersistFailureAbortsPipeline(t *testing.T) {
+	dir := t.TempDir()
+	specDir := scaffoldReviewSpec(t, dir, "SPEC-REVIEW-ABORT-001")
+	setFakeProviderOnPath(t, dir, "claude")
+
+	origWD, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(origWD) }()
+	require.NoError(t, os.Chdir(dir))
+
+	origRunner := specReviewRunOrchestra
+	specReviewRunOrchestra = func(_ context.Context, _ orchestra.OrchestraConfig) (*orchestra.OrchestraResult, error) {
+		// Simulate the SPEC dir vanishing between resolve and persist.
+		if err := os.RemoveAll(specDir); err != nil {
+			return nil, err
+		}
+		return &orchestra.OrchestraResult{Responses: []orchestra.ProviderResponse{{Provider: "claude", Output: "VERDICT: PASS"}}}, nil
+	}
+	defer func() { specReviewRunOrchestra = origRunner }()
+
+	err = runSpecReview(context.Background(), "SPEC-REVIEW-ABORT-001", "consensus", 10)
+	require.Error(t, err, "persist failure must abort the pipeline")
+	assert.Contains(t, err.Error(), "review")
+
+	// The SPEC directory must remain absent — we did not recreate it.
+	_, statErr := os.Stat(specDir)
+	assert.True(t, os.IsNotExist(statErr), "pipeline must not recreate a vanished SPEC dir")
+}
+
 func scaffoldReviewSpec(t *testing.T, dir, specID string) string {
 	t.Helper()
 	require.NoError(t, spec.Scaffold(dir, specID[len("SPEC-"):], "리뷰 테스트"))

--- a/pkg/spec/resolve_test.go
+++ b/pkg/spec/resolve_test.go
@@ -144,6 +144,30 @@ func TestResolveSpecDir_RelativeBaseDirDotFindsSubmodule(t *testing.T) {
 	assert.True(t, strings.HasSuffix(result.SpecDir, filepath.Join("Autopus", ".autopus", "specs", "SPEC-REL-001")))
 }
 
+// Regression guard for GitHub issue #38.
+// A resolver must never treat a caller's SPEC-ID as a substring or prefix match
+// against existing SPEC directories. Silent fuzzy matching caused writes to
+// land on unrelated SPECs (completed/approved status regression, review.md
+// overwrite). This test locks down the exact-match contract explicitly.
+func TestResolveSpecDir_SubstringInputDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Seed two SPECs that share a common infix: "WAITERASE".
+	for _, id := range []string{"SPEC-WAITERASE-001", "SPEC-WAITERASE-002"} {
+		d := filepath.Join(dir, ".autopus", "specs", id)
+		require.NoError(t, os.MkdirAll(d, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(d, "spec.md"), []byte("# "+id), 0o644))
+	}
+
+	// Caller asks for SPEC-OBS-WAITERASE-001 (does not exist on disk).
+	// Must NOT resolve to either of the WAITERASE-* directories.
+	_, err := spec.ResolveSpecDir(dir, "SPEC-OBS-WAITERASE-001")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 // Listing available SPECs must also cope with baseDir=".".
 func TestResolveSpecDir_RelativeBaseDirDotListsAvailable(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- `auto spec review`의 silent corruption 경로 차단: persist 실패(`PersistFindings`/`PersistReview`/`syncReviewedSpecStatus`)가 stderr 로그만 남기고 "판정: PASS"로 success exit 하던 흐름을 **fail-fast**로 교체.
- `syncReviewedSpecStatus`에 status gate 추가: 이미 `completed`/`implemented` 상태인 SPEC을 PASS 리뷰가 `approved`로 역행시키지 못하도록 차단.
- regression 테스트 3건 추가로 향후 동일 회귀 차단.

## Root cause summary (#38)
관찰된 증상은 두 CLI 호출이 혼합 보고된 것으로 재구성됨:
- **호출 A**: 디렉토리 부재 SPEC-ID → persist 3건 실패했으나 stderr 로그만 남기고 "판정: PASS" 성공 종료 (silent success)
- **호출 B**: 이미 `completed`인 SPEC → PASS 리뷰가 status를 `approved`로 역행 + review.md 201줄 → 6줄 stub으로 덮어씀

코드 경로 분석 결과 단일 CLI 호출이 서로 다른 두 SPEC을 수정할 수 있는 경로는 **없음** (specDir 단일 고정, orchestra provider는 stdout-only, 재귀 auto exec 없음 — explorer agent high confidence). 본 PR은 관찰된 데이터 파괴 증상의 **직접 enabler**인 silent success와 status 역행을 차단.

## Test plan
- [x] \`go test -race ./pkg/spec/... ./internal/cli/...\` 전체 PASS (27.5s)
- [x] \`TestResolveSpecDir_SubstringInputDoesNotMatch\` (exact-match 계약 regression)
- [x] \`TestRunSpecReview_RefusesToRegressCompletedStatus\` (status gate)
- [x] \`TestRunSpecReview_PersistFailureAbortsPipeline\` (이슈의 silent success 메커니즘 재현 후 fail-fast 동작 확인)
- [x] \`TestRunSpecReview_PassApprovesSpec\`, \`TestRunSpecReview_ReviseDoesNotApproveSpec\` 회귀 없음
- [ ] 실제 orchestra providers (claude/codex/gemini) E2E 검증 — 바이너리 필요, 후속 작업

## Out of scope (후속 PR)
- **review.md 기존 내용 보존**: stub overwrite 자체는 여전히 발생. 백업/append/rotate 전략이 필요.
- **SPEC 디렉토리 소실의 최종 원인**: autopus-adk 코드에 \`.autopus/specs\` 삭제 경로 없음 → git reflog/telemetry로 운영 레벨 추적 필요.
- **preflight writability check**: Fix 1(persist fail-fast)이 write 시점에 이미 차단하므로 중복 방어 — 추후 orchestra 비용 절감 목적으로 추가 가능.

Closes #38

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)