### PR TITLE
fix: preserve existing Claude statusLine config

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,10 @@ auto init
 
 `auto init` scans your machine for supported installed AI coding CLIs (Claude Code, Codex, Gemini CLI, OpenCode) and generates **native configuration** for each one — rules, skills, agents, and platform-specific settings — all from a single `autopus.yaml`.
 
+Claude Code statusline note:
+- If `.claude/settings.json` already has a `statusLine.command`, `auto init` / `auto update` now lets you choose `keep`, `merge`, or `replace` in interactive mode.
+- You can force the same behavior non-interactively with `--statusline-mode keep|merge|replace`.
+
 ```
 ✓ Detected: claude-code, codex, gemini-cli, opencode
 ✓ Generated: .claude/rules/, .claude/skills/, .claude/agents/, CLAUDE.md
@@ -708,6 +712,8 @@ auto update
 ```
 
 Regenerates `.claude/*`, `.codex/*`, `.gemini/*`, `.opencode/*`, `.agents/skills/*`, and other platform-specific files from the latest templates. With `skills.compiler.mode: split`, the update preview/apply flow also manages `.opencode/skills/*` and `.autopus/plugins/auto/skills/*`, including stale artifact pruning. Your custom edits outside `AUTOPUS:BEGIN`~`AUTOPUS:END` markers are preserved. Newly installed platforms are auto-detected.
+
+If Claude Code already has a user-managed `statusLine.command`, the update flow defaults to preserving it, can merge it with the managed Autopus statusline, or replace it entirely via `--statusline-mode keep|merge|replace`.
 
 **Both at once:**
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -506,6 +506,10 @@ Windows에서 `powershell -c ...`를 Git Bash 안에서 실행한 경우에는, 
 
 `auto init`은 설치된 AI 코딩 CLI(Claude Code, Codex, Gemini CLI, OpenCode)를 자동 감지하고, 각 플랫폼에 맞는 **네이티브 설정** — 규칙, 스킬, 에이전트 — 을 하나의 `autopus.yaml`에서 생성합니다.
 
+Claude Code statusline 참고:
+- `.claude/settings.json`에 기존 `statusLine.command`가 있으면, `auto init` / `auto update` 인터랙티브 실행 시 `keep`, `merge`, `replace` 중 하나를 고를 수 있습니다.
+- 비대화형에서는 `--statusline-mode keep|merge|replace`로 같은 동작을 명시할 수 있습니다.
+
 플랫폼별 명령 문법:
 - Codex: 생성된 로컬 플러그인을 설치한 뒤 `@auto ...`를 사용하고, 그 전에는 `$auto ...`를 사용합니다
 - OpenCode: `/auto ...` 또는 `/auto-<subcommand> ...`를 사용합니다
@@ -603,6 +607,8 @@ auto update
 ```
 
 `.claude/*`, `.codex/*`, `.gemini/*`, `.opencode/*`, `.agents/skills/*` 등의 하네스 파일을 갱신합니다. `skills.compiler.mode: split`이 켜져 있으면 `.opencode/skills/*`와 `.autopus/plugins/auto/skills/*`도 preview/apply 대상이 되며 stale artifact prune까지 함께 처리합니다. `AUTOPUS:BEGIN`~`AUTOPUS:END` 마커 바깥의 사용자 편집은 보존됩니다. 새로 설치된 플랫폼이 있으면 자동 감지하여 해당 파일도 생성합니다.
+
+Claude Code에 기존 user-managed `statusLine.command`가 있으면, update는 기본적으로 이를 보존합니다. 필요하면 `--statusline-mode keep|merge|replace`로 기존 statusline 유지, Autopus와 2줄 병합, 완전 교체를 명시할 수 있습니다.
 
 **한 줄로 둘 다:**
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -37,6 +37,7 @@ func newInitCmd() *cobra.Command {
 		project      string
 		platforms    string
 		noReviewGate bool
+		statusLine   string
 		yes          bool
 	)
 
@@ -172,6 +173,14 @@ func newInitCmd() *cobra.Command {
 			if err := config.Save(dir, cfg); err != nil {
 				return fmt.Errorf("autopus.yaml 저장 실패: %w", err)
 			}
+			if err := validateStatusLineMode(statusLine); err != nil {
+				return err
+			}
+
+			statusLineSummary, err := applyStatusLineMode(cmd, dir, cfg, statusLine, isStdinTTY() && !yes)
+			if err != nil {
+				return err
+			}
 
 			warnParentRuleConflicts(cmd, dir, cfg, yes)
 
@@ -202,6 +211,9 @@ func newInitCmd() *cobra.Command {
 				{Key: "Platforms", Value: strings.Join(cfg.Platforms, ", ")},
 				{Key: "Language", Value: fmt.Sprintf("comments=%s, commits=%s, ai=%s", cfg.Language.Comments, cfg.Language.Commits, cfg.Language.AIResponses)},
 			})
+			if statusLineSummary != "" {
+				tui.Info(out, statusLineSummary)
+			}
 			// Context-aware next step guidance (R9)
 			if home, err := os.UserHomeDir(); err == nil {
 				workerConfigPath := filepath.Join(home, ".config", "autopus", "worker.yaml")
@@ -226,6 +238,7 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().StringVar(&project, "project", "", "프로젝트 이름")
 	cmd.Flags().StringVar(&platforms, "platforms", "", "설치할 플랫폼 목록 (쉼표 구분, 예: claude-code,codex)")
 	cmd.Flags().BoolVar(&noReviewGate, "no-review-gate", false, "Disable review gate")
+	cmd.Flags().StringVar(&statusLine, "statusline-mode", "", "Claude statusLine handling: keep, merge, replace")
 	cmd.Flags().BoolVar(&yes, "yes", false, "Non-interactive mode (use defaults)")
 
 	return cmd

--- a/internal/cli/statusline_mode.go
+++ b/internal/cli/statusline_mode.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/insajin/autopus-adk/pkg/adapter/claude"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+func normalizeStatusLineMode(raw string) config.StatusLineMode {
+	return config.NormalizeStatusLineMode(raw)
+}
+
+func validateStatusLineMode(raw string) error {
+	mode := normalizeStatusLineMode(raw)
+	if mode == "" || mode.IsValid() {
+		return nil
+	}
+	return fmt.Errorf("invalid --statusline-mode %q: must be keep, merge, or replace", raw)
+}
+
+func applyStatusLineMode(cmd *cobra.Command, dir string, cfg *config.HarnessConfig, rawMode string, allowPrompt bool) (string, error) {
+	if cfg == nil || !containsPlatform(cfg.Platforms, "claude-code") {
+		return "", nil
+	}
+
+	existing := claude.InspectStatusLine(dir)
+	mode := normalizeStatusLineMode(rawMode)
+	if mode == "" {
+		switch {
+		case existing.IsAutopusMerge():
+			mode = config.StatusLineModeMerge
+		case existing.IsAutopusReplace() || !existing.HasCommand():
+			mode = config.StatusLineModeReplace
+		case existing.IsUserManaged() && allowPrompt:
+			mode = promptStatusLineMode(cmd.OutOrStdout(), existing.Command)
+		default:
+			mode = config.StatusLineModeKeep
+		}
+	}
+
+	cfg.Runtime.StatusLine.Mode = mode
+	return describeStatusLineDecision(existing, mode), nil
+}
+
+func promptStatusLineMode(out io.Writer, existingCommand string) config.StatusLineMode {
+	options := []string{
+		"Keep existing statusLine (recommended)",
+		"Merge existing + Autopus statusLine",
+		"Replace with Autopus statusLine",
+	}
+	question := fmt.Sprintf("Existing Claude statusLine detected:\n    %s\n  How should Autopus handle it?", existingCommand)
+	switch promptChoice(out, question, options, 0) {
+	case 1:
+		return config.StatusLineModeMerge
+	case 2:
+		return config.StatusLineModeReplace
+	default:
+		return config.StatusLineModeKeep
+	}
+}
+
+func describeStatusLineDecision(existing claude.StatusLineState, mode config.StatusLineMode) string {
+	switch mode {
+	case config.StatusLineModeKeep:
+		if existing.IsUserManaged() {
+			return fmt.Sprintf("Claude statusLine: existing command preserved (%s)", existing.Command)
+		}
+		if existing.IsAutopusMerge() {
+			return "Claude statusLine: existing combined mode preserved"
+		}
+		if existing.IsAutopusReplace() {
+			return "Claude statusLine: existing Autopus statusLine preserved"
+		}
+		return "Claude statusLine: no existing command to preserve"
+	case config.StatusLineModeMerge:
+		if existing.IsUserManaged() {
+			return fmt.Sprintf("Claude statusLine: merged existing command + Autopus (%s)", existing.Command)
+		}
+		return "Claude statusLine: combined mode enabled"
+	case config.StatusLineModeReplace:
+		if existing.IsUserManaged() {
+			return fmt.Sprintf("Claude statusLine: replaced existing command with Autopus (%s)", existing.Command)
+		}
+		return "Claude statusLine: Autopus statusLine enabled"
+	default:
+		return ""
+	}
+}
+
+func buildStatusLinePreviewItems(dir string, cfg *config.HarnessConfig) []previewItem {
+	if cfg == nil || !containsPlatform(cfg.Platforms, "claude-code") {
+		return nil
+	}
+
+	existing := claude.InspectStatusLine(dir)
+	mode := cfg.Runtime.StatusLine.Mode
+	if !mode.IsValid() {
+		mode = config.StatusLineModeReplace
+	}
+
+	item := previewItem{
+		Path:     ".claude/settings.json",
+		Category: "generated_surface",
+		Scope:    "claude-code",
+	}
+
+	switch mode {
+	case config.StatusLineModeKeep:
+		if !existing.IsUserManaged() {
+			return nil
+		}
+		item.Kind = "retain"
+		item.Reason = "existing user-managed statusLine would be preserved; rerun with --statusline-mode merge or replace to change it"
+	case config.StatusLineModeMerge:
+		item.Kind = "emit"
+		if existing.IsUserManaged() {
+			item.Reason = "Claude statusLine would switch to combined mode (existing command + Autopus)"
+		} else {
+			item.Reason = "Claude statusLine would stay in combined mode and refresh managed wrapper assets"
+		}
+	case config.StatusLineModeReplace:
+		item.Kind = "emit"
+		if existing.IsUserManaged() {
+			item.Reason = "Claude statusLine would be replaced with Autopus via --statusline-mode replace"
+		} else {
+			item.Reason = "Claude statusLine would point to the managed Autopus command"
+		}
+	default:
+		return nil
+	}
+
+	return []previewItem{item}
+}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -24,7 +24,7 @@ import (
 func newUpdateCmd() *cobra.Command {
 	var dir string
 	var selfFlag, checkOnly, force, yesFlag, previewMode bool
-	var targetVersion string
+	var targetVersion, statusLine string
 
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -56,6 +56,10 @@ func newUpdateCmd() *cobra.Command {
 			}
 			if err != nil {
 				return fmt.Errorf("설정 로드 실패: %w", err)
+			}
+
+			if err := validateStatusLineMode(statusLine); err != nil {
+				return err
 			}
 
 			if previewMode {
@@ -90,6 +94,9 @@ func newUpdateCmd() *cobra.Command {
 				}
 
 				effectiveCfg := applyFlagCC21Overrides(previewCfg, globalFlagsFromContext(cmd.Context()))
+				if _, modeErr := applyStatusLineMode(cmd, dir, effectiveCfg, statusLine, false); modeErr != nil {
+					return modeErr
+				}
 				preview, previewErr := buildUpdatePreview(cmd.Context(), dir, effectiveCfg)
 				if previewErr != nil {
 					return previewErr
@@ -117,6 +124,10 @@ func newUpdateCmd() *cobra.Command {
 			// 프로젝트 설정 프롬프트 (미설정 항목만, --yes 시 스킵)
 			if !yesFlag {
 				promptLanguageSettings(cmd, dir, cfg)
+			}
+			statusLineSummary, statusLineErr := applyStatusLineMode(cmd, dir, cfg, statusLine, isStdinTTY() && !yesFlag)
+			if statusLineErr != nil {
+				return statusLineErr
 			}
 			warnParentRuleConflicts(cmd, dir, cfg, yesFlag)
 
@@ -151,6 +162,9 @@ func newUpdateCmd() *cobra.Command {
 				}
 			}
 
+			if statusLineSummary != "" {
+				fmt.Fprintf(cmd.OutOrStdout(), "  • %s\n", statusLineSummary)
+			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Update complete: %d platform(s) updated\n", updated)
 			return nil
 		},
@@ -162,6 +176,7 @@ func newUpdateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&force, "force", false, "같은 버전이라도 재설치 또는 개발 빌드 업데이트 강제")
 	cmd.Flags().StringVar(&targetVersion, "version", "", "특정 버전 설치 (기본값: 최신 버전)")
 	cmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, "모든 프롬프트를 기본값으로 자동 수락")
+	cmd.Flags().StringVar(&statusLine, "statusline-mode", "", "Claude statusLine handling: keep, merge, replace")
 	cmd.Flags().BoolVar(&previewMode, "plan", false, "변경 예정 파일만 계산하고 쓰지 않음")
 	cmd.Flags().BoolVar(&previewMode, "preview", false, "변경 예정 파일만 계산하고 쓰지 않음")
 	cmd.Flags().BoolVar(&previewMode, "dry-run", false, "변경 예정 파일만 계산하고 쓰지 않음")

--- a/internal/cli/update_preview.go
+++ b/internal/cli/update_preview.go
@@ -51,6 +51,8 @@ func buildUpdatePreview(ctx context.Context, dir string, cfg *config.HarnessConf
 		backupNeeded = backupNeeded || needsBackup
 	}
 
+	result.Items = append(result.Items, buildStatusLinePreviewItems(dir, cfg)...)
+
 	if backupNeeded {
 		result.Items = append(result.Items, previewItem{
 			Path:     ".autopus/backup/<timestamp>/",

--- a/internal/cli/update_preview_test.go
+++ b/internal/cli/update_preview_test.go
@@ -107,6 +107,37 @@ func TestUpdateCmd_PlanShowsLegacyConfigNormalizationWithoutWriting(t *testing.T
 	assert.Contains(t, out.String(), "legacy platform names would be normalized")
 }
 
+func TestUpdateCmd_PlanShowsStatusLineKeepHint(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	initCmd := newTestRootCmd()
+	initCmd.SetArgs([]string{"init", "--dir", dir, "--project", "preview-proj", "--platforms", "claude-code", "--yes"})
+	require.NoError(t, initCmd.Execute())
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(`{
+  "statusLine": {
+    "type": "command",
+    "command": "node ~/.claude/hud/omc-hud.mjs",
+    "padding": 2
+  }
+}`), 0o644))
+
+	var out bytes.Buffer
+	updateCmd := newTestRootCmd()
+	updateCmd.SetOut(&out)
+	updateCmd.SetErr(&out)
+	updateCmd.SetArgs([]string{"update", "--dir", dir, "--plan", "--yes"})
+	require.NoError(t, updateCmd.Execute())
+
+	output := out.String()
+	assert.Contains(t, output, ".claude/settings.json")
+	assert.Contains(t, output, "statusLine would be preserved")
+	assert.Contains(t, output, "--statusline-mode merge or replace")
+}
+
 func TestUpdateCmd_PlanShowsSplitCompilerEmitRetainPruneAndChecksumDiff(t *testing.T) {
 	dir := t.TempDir()
 	configurePreviewBinaries(t, "codex", "opencode")

--- a/internal/cli/update_statusline_test.go
+++ b/internal/cli/update_statusline_test.go
@@ -1,0 +1,48 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateCmd_StatusLineModeMergeCombinesExistingCommand(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	initCmd := newTestRootCmd()
+	initCmd.SetArgs([]string{"init", "--dir", dir, "--project", "test-proj", "--platforms", "claude-code", "--yes"})
+	require.NoError(t, initCmd.Execute())
+
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	require.NoError(t, os.WriteFile(settingsPath, []byte(`{
+  "statusLine": {
+    "type": "command",
+    "command": "node ~/.claude/hud/omc-hud.mjs",
+    "padding": 2
+  }
+}`), 0o644))
+
+	var out bytes.Buffer
+	updateCmd := newTestRootCmd()
+	updateCmd.SetOut(&out)
+	updateCmd.SetErr(&out)
+	updateCmd.SetArgs([]string{"update", "--dir", dir, "--yes", "--statusline-mode", "merge"})
+	require.NoError(t, updateCmd.Execute())
+
+	updated, err := os.ReadFile(settingsPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(updated), ".claude/statusline-combined.sh")
+
+	userCommand, err := os.ReadFile(filepath.Join(dir, ".claude", "statusline-user-command.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "node ~/.claude/hud/omc-hud.mjs\n", string(userCommand))
+
+	assert.FileExists(t, filepath.Join(dir, ".claude", "statusline-combined.sh"))
+	assert.Contains(t, out.String(), "merged existing command + Autopus")
+}

--- a/pkg/adapter/claude/claude.go
+++ b/pkg/adapter/claude/claude.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"os/exec"
 
+	"github.com/insajin/autopus-adk/pkg/config"
 	tmpl "github.com/insajin/autopus-adk/pkg/template"
 )
 
@@ -22,8 +23,9 @@ const (
 // @AX:ANCHOR: PlatformAdapter 인터페이스의 claude-code 구현체 — 다수의 CLI 커맨드에서 사용됨
 // @AX:REASON: [AUTO] init/update/doctor/platform 커맨드에서 참조
 type Adapter struct {
-	root   string       // project root path
-	engine *tmpl.Engine // template rendering engine
+	root           string                // project root path
+	engine         *tmpl.Engine          // template rendering engine
+	statusLineMode config.StatusLineMode // runtime-only statusline override
 }
 
 // New는 현재 디렉터리를 루트로 하는 어댑터를 생성한다.

--- a/pkg/adapter/claude/claude_files.go
+++ b/pkg/adapter/claude/claude_files.go
@@ -67,38 +67,6 @@ func (a *Adapter) prepareMCPConfig(cfg *config.HarnessConfig) ([]adapter.FileMap
 	}}, nil
 }
 
-// prepareStatusline reads statusline.sh from embedded FS and returns a FileMapping.
-func (a *Adapter) prepareStatusline() ([]adapter.FileMapping, error) {
-	data, err := contentfs.FS.ReadFile("statusline.sh")
-	if err != nil {
-		return nil, fmt.Errorf("statusline.sh 읽기 실패: %w", err)
-	}
-	return []adapter.FileMapping{{
-		TargetPath:      filepath.Join(".claude", "statusline.sh"),
-		OverwritePolicy: adapter.OverwriteAlways,
-		Checksum:        checksum(string(data)),
-		Content:         data,
-	}}, nil
-}
-
-// copyStatusline copies statusline.sh to the target project.
-func (a *Adapter) copyStatusline() ([]adapter.FileMapping, error) {
-	data, err := contentfs.FS.ReadFile("statusline.sh")
-	if err != nil {
-		return nil, fmt.Errorf("statusline.sh 읽기 실패: %w", err)
-	}
-	destPath := filepath.Join(a.root, ".claude", "statusline.sh")
-	if err := os.WriteFile(destPath, data, 0755); err != nil {
-		return nil, fmt.Errorf("statusline.sh 쓰기 실패: %w", err)
-	}
-	return []adapter.FileMapping{{
-		TargetPath:      filepath.Join(".claude", "statusline.sh"),
-		OverwritePolicy: adapter.OverwriteAlways,
-		Checksum:        checksum(string(data)),
-		Content:         data,
-	}}, nil
-}
-
 // renderRouterCommand는 단일 라우터 템플릿(auto-router.md.tmpl)을 렌더링하여
 // .claude/skills/auto/SKILL.md 파일을 생성한다.
 func (a *Adapter) renderRouterCommand(cfg *config.HarnessConfig) ([]adapter.FileMapping, error) {

--- a/pkg/adapter/claude/claude_generate.go
+++ b/pkg/adapter/claude/claude_generate.go
@@ -74,6 +74,12 @@ func (a *Adapter) Generate(ctx context.Context, cfg *config.HarnessConfig) (*ada
 	}
 	files = append(files, mcpFiles...)
 
+	statusFiles, err := a.copyStatuslineFiles(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("statusline 복사 실패: %w", err)
+	}
+	files = append(files, statusFiles...)
+
 	if err := a.applyHooksAndPermissions(ctx, cfg); err != nil {
 		return nil, err
 	}
@@ -93,12 +99,6 @@ func (a *Adapter) Generate(ctx context.Context, cfg *config.HarnessConfig) (*ada
 		return nil, fmt.Errorf("file-size-limit.md 쓰기 실패: %w", err)
 	}
 	files = append(files, fileSizeRule)
-
-	statusFiles, err := a.copyStatusline()
-	if err != nil {
-		return nil, fmt.Errorf("statusline 복사 실패: %w", err)
-	}
-	files = append(files, statusFiles...)
 
 	// Managed hook assets are split between autopus/ and root hook files.
 	hookFiles, err := a.copyContentFiles(cfg, "hooks", filepath.Join(".claude", "hooks", "autopus"))

--- a/pkg/adapter/claude/claude_hooks_test.go
+++ b/pkg/adapter/claude/claude_hooks_test.go
@@ -27,8 +27,15 @@ func TestClaudeAdapter_InstallHooks_Empty(t *testing.T) {
 
 	// settings.json이 생성되어야 함
 	settingsPath := filepath.Join(dir, ".claude", "settings.json")
-	_, statErr := os.Stat(settingsPath)
-	assert.NoError(t, statErr)
+	data, readErr := os.ReadFile(settingsPath)
+	require.NoError(t, readErr)
+
+	var settings map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &settings))
+
+	statusLine, ok := settings["statusLine"].(map[string]interface{})
+	require.True(t, ok, "statusLine 필드가 있어야 함")
+	assert.Equal(t, ".claude/statusline.sh", statusLine["command"])
 }
 
 // TestClaudeAdapter_InstallHooks_WithHooks는 훅 설정을 포함한 InstallHooks를 테스트한다.
@@ -136,6 +143,42 @@ func TestClaudeAdapter_InstallHooks_MergesExisting(t *testing.T) {
 	assert.True(t, hasHooks)
 	theme, _ := result["theme"].(string)
 	assert.Equal(t, "dark", theme)
+}
+
+func TestClaudeAdapter_InstallHooks_PreservesExistingStatusLine(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	settingsDir := filepath.Join(dir, ".claude")
+	require.NoError(t, os.MkdirAll(settingsDir, 0755))
+
+	existing := map[string]interface{}{
+		"statusLine": map[string]interface{}{
+			"type":    "command",
+			"command": "node ~/.claude/hud/omc-hud.mjs",
+			"padding": 2,
+		},
+	}
+	data, err := json.Marshal(existing)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.json"), data, 0644))
+
+	a := claude.NewWithRoot(dir)
+	err = a.InstallHooks(context.Background(), []adapter.HookConfig{
+		{Event: "PreToolUse", Matcher: "Bash", Type: "command", Command: "auto check --arch --quiet", Timeout: 30},
+	}, nil)
+	require.NoError(t, err)
+
+	updated, readErr := os.ReadFile(filepath.Join(settingsDir, "settings.json"))
+	require.NoError(t, readErr)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(updated, &result))
+
+	statusLine, ok := result["statusLine"].(map[string]interface{})
+	require.True(t, ok, "기존 statusLine이 유지되어야 함")
+	assert.Equal(t, "node ~/.claude/hud/omc-hud.mjs", statusLine["command"])
+	assert.EqualValues(t, 2, statusLine["padding"])
 }
 
 // TestClaudeAdapter_InstallHooks_InvalidJSON은 잘못된 JSON settings.json이 있을 때를 테스트한다.

--- a/pkg/adapter/claude/claude_prepare_files.go
+++ b/pkg/adapter/claude/claude_prepare_files.go
@@ -47,7 +47,7 @@ func (a *Adapter) prepareFiles(cfg *config.HarnessConfig) ([]adapter.FileMapping
 	}
 	files = append(files, mcpFiles...)
 
-	statusFiles, err := a.prepareStatusline()
+	statusFiles, err := a.prepareStatuslineFiles(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("statusline 준비 실패: %w", err)
 	}

--- a/pkg/adapter/claude/claude_settings.go
+++ b/pkg/adapter/claude/claude_settings.go
@@ -12,11 +12,10 @@ import (
 	"github.com/insajin/autopus-adk/pkg/content"
 )
 
-const autopusClaudeStatusLineCommand = ".claude/statusline.sh"
-
 // applyHooksAndPermissions는 hooks와 permissions를 .claude/settings.json에 설치한다.
 // Always writes settings.json — DetectPermissions always returns non-nil with common defaults.
 func (a *Adapter) applyHooksAndPermissions(ctx context.Context, cfg *config.HarnessConfig) error {
+	a.statusLineMode = resolveStatusLineMode(cfg, InspectStatusLine(a.root))
 	hookConfigs, gitHooks, _ := content.GenerateProjectHookConfigs(cfg, "claude-code", a.SupportsHooks())
 	perms := content.DetectPermissions(a.root, cfg.Hooks.Permissions)
 	if err := a.InstallHooks(ctx, hookConfigs, perms); err != nil {
@@ -118,9 +117,14 @@ func (a *Adapter) InstallHooks(_ context.Context, hooks []adapter.HookConfig, pe
 		settings["permissions"] = permMap
 	}
 
-	// Preserve an existing user-managed statusLine instead of clobbering it.
-	// If the workspace already points to the Autopus statusline, refresh it.
-	if shouldInstallAutopusStatusLine(settings["statusLine"]) {
+	mode := a.statusLineMode
+	if !mode.IsValid() {
+		mode = resolveStatusLineMode(nil, statusLineStateFromValue(settings["statusLine"]))
+	}
+	switch mode {
+	case config.StatusLineModeMerge:
+		settings["statusLine"] = defaultClaudeCombinedStatusLine()
+	case config.StatusLineModeReplace:
 		settings["statusLine"] = defaultClaudeStatusLine()
 	}
 
@@ -170,16 +174,10 @@ func defaultClaudeStatusLine() map[string]any {
 	}
 }
 
-func shouldInstallAutopusStatusLine(existing any) bool {
-	statusLine, ok := existing.(map[string]any)
-	if !ok || len(statusLine) == 0 {
-		return true
+func defaultClaudeCombinedStatusLine() map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": autopusClaudeCombinedStatusLineCommand,
+		"padding": 1,
 	}
-
-	command, ok := statusLine["command"].(string)
-	if !ok || command == "" {
-		return false
-	}
-
-	return command == autopusClaudeStatusLineCommand
 }

--- a/pkg/adapter/claude/claude_settings.go
+++ b/pkg/adapter/claude/claude_settings.go
@@ -12,6 +12,8 @@ import (
 	"github.com/insajin/autopus-adk/pkg/content"
 )
 
+const autopusClaudeStatusLineCommand = ".claude/statusline.sh"
+
 // applyHooksAndPermissions는 hooks와 permissions를 .claude/settings.json에 설치한다.
 // Always writes settings.json — DetectPermissions always returns non-nil with common defaults.
 func (a *Adapter) applyHooksAndPermissions(ctx context.Context, cfg *config.HarnessConfig) error {
@@ -116,11 +118,10 @@ func (a *Adapter) InstallHooks(_ context.Context, hooks []adapter.HookConfig, pe
 		settings["permissions"] = permMap
 	}
 
-	// Statusline configuration — always set to autopus statusline
-	settings["statusLine"] = map[string]any{
-		"type":    "command",
-		"command": ".claude/statusline.sh",
-		"padding": 1,
+	// Preserve an existing user-managed statusLine instead of clobbering it.
+	// If the workspace already points to the Autopus statusline, refresh it.
+	if shouldInstallAutopusStatusLine(settings["statusLine"]) {
+		settings["statusLine"] = defaultClaudeStatusLine()
 	}
 
 	out, err := json.MarshalIndent(settings, "", "  ")
@@ -159,4 +160,26 @@ func mergeUnique(base, add []string) []string {
 		}
 	}
 	return result
+}
+
+func defaultClaudeStatusLine() map[string]any {
+	return map[string]any{
+		"type":    "command",
+		"command": autopusClaudeStatusLineCommand,
+		"padding": 1,
+	}
+}
+
+func shouldInstallAutopusStatusLine(existing any) bool {
+	statusLine, ok := existing.(map[string]any)
+	if !ok || len(statusLine) == 0 {
+		return true
+	}
+
+	command, ok := statusLine["command"].(string)
+	if !ok || command == "" {
+		return false
+	}
+
+	return command == autopusClaudeStatusLineCommand
 }

--- a/pkg/adapter/claude/claude_statusline.go
+++ b/pkg/adapter/claude/claude_statusline.go
@@ -1,0 +1,192 @@
+package claude
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	contentfs "github.com/insajin/autopus-adk/content"
+	"github.com/insajin/autopus-adk/pkg/adapter"
+	"github.com/insajin/autopus-adk/pkg/config"
+)
+
+const (
+	autopusClaudeStatusLineCommand         = ".claude/statusline.sh"
+	autopusClaudeCombinedStatusLineCommand = ".claude/statusline-combined.sh"
+	autopusClaudeUserCommandFile           = ".claude/statusline-user-command.txt"
+)
+
+type StatusLineState struct {
+	Command string
+}
+
+func InspectStatusLine(root string) StatusLineState {
+	settingsPath := filepath.Join(root, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		return StatusLineState{}
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return StatusLineState{}
+	}
+
+	statusLine, ok := settings["statusLine"].(map[string]any)
+	if !ok {
+		return StatusLineState{}
+	}
+
+	command, _ := statusLine["command"].(string)
+	return StatusLineState{Command: strings.TrimSpace(command)}
+}
+
+func statusLineStateFromValue(value any) StatusLineState {
+	statusLine, ok := value.(map[string]any)
+	if !ok {
+		return StatusLineState{}
+	}
+	command, _ := statusLine["command"].(string)
+	return StatusLineState{Command: strings.TrimSpace(command)}
+}
+
+func (s StatusLineState) HasCommand() bool {
+	return s.Command != ""
+}
+
+func (s StatusLineState) IsAutopusReplace() bool {
+	return s.Command == autopusClaudeStatusLineCommand
+}
+
+func (s StatusLineState) IsAutopusMerge() bool {
+	return s.Command == autopusClaudeCombinedStatusLineCommand
+}
+
+func (s StatusLineState) IsUserManaged() bool {
+	return s.HasCommand() && !s.IsAutopusReplace() && !s.IsAutopusMerge()
+}
+
+func resolveStatusLineMode(cfg *config.HarnessConfig, existing StatusLineState) config.StatusLineMode {
+	if cfg != nil && cfg.Runtime.StatusLine.Mode.IsValid() {
+		return cfg.Runtime.StatusLine.Mode
+	}
+	if existing.IsAutopusMerge() {
+		return config.StatusLineModeMerge
+	}
+	if existing.IsAutopusReplace() || !existing.HasCommand() {
+		return config.StatusLineModeReplace
+	}
+	return config.StatusLineModeKeep
+}
+
+func (a *Adapter) prepareStatuslineFiles(cfg *config.HarnessConfig) ([]adapter.FileMapping, error) {
+	mainData, err := contentfs.FS.ReadFile("statusline.sh")
+	if err != nil {
+		return nil, fmt.Errorf("statusline.sh 읽기 실패: %w", err)
+	}
+
+	existing := InspectStatusLine(a.root)
+	mode := resolveStatusLineMode(cfg, existing)
+
+	files := []adapter.FileMapping{
+		{
+			TargetPath:      filepath.Join(".claude", "statusline.sh"),
+			OverwritePolicy: adapter.OverwriteAlways,
+			Checksum:        checksum(string(mainData)),
+			Content:         mainData,
+		},
+		{
+			TargetPath:      filepath.Join(".claude", "statusline-combined.sh"),
+			OverwritePolicy: adapter.OverwriteAlways,
+			Checksum:        checksum(claudeCombinedStatuslineScript),
+			Content:         []byte(claudeCombinedStatuslineScript),
+		},
+	}
+
+	userCommand := a.resolveMergedUserStatusLineCommand(existing, mode)
+	userCommandContent := userCommand
+	if userCommandContent != "" && !strings.HasSuffix(userCommandContent, "\n") {
+		userCommandContent += "\n"
+	}
+	files = append(files, adapter.FileMapping{
+		TargetPath:      filepath.Join(".claude", "statusline-user-command.txt"),
+		OverwritePolicy: adapter.OverwriteAlways,
+		Checksum:        checksum(userCommandContent),
+		Content:         []byte(userCommandContent),
+	})
+
+	return files, nil
+}
+
+func (a *Adapter) copyStatuslineFiles(cfg *config.HarnessConfig) ([]adapter.FileMapping, error) {
+	files, err := a.prepareStatuslineFiles(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		targetPath := filepath.Join(a.root, file.TargetPath)
+		perm := os.FileMode(0644)
+		if strings.HasSuffix(file.TargetPath, ".sh") {
+			perm = 0755
+		}
+		if err := os.WriteFile(targetPath, file.Content, perm); err != nil {
+			return nil, fmt.Errorf("%s 쓰기 실패: %w", filepath.Base(file.TargetPath), err)
+		}
+	}
+
+	return files, nil
+}
+
+func (a *Adapter) resolveMergedUserStatusLineCommand(existing StatusLineState, mode config.StatusLineMode) string {
+	if mode != config.StatusLineModeMerge {
+		return ""
+	}
+	if existing.IsUserManaged() {
+		return existing.Command
+	}
+	if !existing.IsAutopusMerge() {
+		return ""
+	}
+
+	data, err := os.ReadFile(filepath.Join(a.root, ".claude", "statusline-user-command.txt"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+const claudeCombinedStatuslineScript = `#!/bin/sh
+# Combined Claude statusline wrapper.
+# Runs the preserved user command first, then the Autopus statusline.
+
+set -eu
+
+payload=$(cat)
+user_command=""
+
+if [ -f ".claude/statusline-user-command.txt" ]; then
+  user_command=$(cat ".claude/statusline-user-command.txt")
+fi
+
+user_output=""
+if [ -n "$user_command" ]; then
+  user_output=$(printf '%s' "$payload" | sh -lc "$user_command" 2>/dev/null || true)
+fi
+
+autopus_output=$(printf '%s' "$payload" | .claude/statusline.sh 2>/dev/null || true)
+
+if [ -n "$user_output" ] && [ -n "$autopus_output" ]; then
+  printf "%s\n%s\n" "$user_output" "$autopus_output"
+  exit 0
+fi
+
+if [ -n "$user_output" ]; then
+  printf "%s\n" "$user_output"
+  exit 0
+fi
+
+printf "%s\n" "$autopus_output"
+`

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -1,0 +1,32 @@
+package config
+
+import "strings"
+
+type StatusLineMode string
+
+const (
+	StatusLineModeKeep    StatusLineMode = "keep"
+	StatusLineModeMerge   StatusLineMode = "merge"
+	StatusLineModeReplace StatusLineMode = "replace"
+)
+
+type RuntimeConf struct {
+	StatusLine StatusLineRuntimeConf `yaml:"-"`
+}
+
+type StatusLineRuntimeConf struct {
+	Mode StatusLineMode `yaml:"-"`
+}
+
+func NormalizeStatusLineMode(raw string) StatusLineMode {
+	return StatusLineMode(strings.ToLower(strings.TrimSpace(raw)))
+}
+
+func (m StatusLineMode) IsValid() bool {
+	switch m {
+	case StatusLineModeKeep, StatusLineModeMerge, StatusLineModeReplace:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -82,6 +82,7 @@ type HarnessConfig struct {
 	Profiles     ProfilesConf     `yaml:"profiles,omitempty"`
 	UsageProfile UsageProfile     `yaml:"usage_profile,omitempty"` // developer (default) or fullstack
 	Hints        HintsConf        `yaml:"hints,omitempty"`
+	Runtime      RuntimeConf      `yaml:"-"`
 }
 
 // FeaturesConf holds feature-flag namespaces.


### PR DESCRIPTION
## Summary
- preserve an existing user-managed `.claude/settings.json` `statusLine` instead of clobbering it
- keep refreshing the Autopus statusline only when the workspace already points to `.claude/statusline.sh`
- add regression coverage for default statusline generation and existing statusline preservation

## Testing
- go test ./pkg/adapter/claude

Fixes #48